### PR TITLE
Add in-game feedback modal with Modem API submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ After GitHub Pages deploys, play at:
 - `F`: Fullscreen
 - `U`: Ultra scale toggle
 - `Enter`: Start / Restart
+- `F1` or `?`: Open in-game feedback form
 
 ## What Is Implemented
 
@@ -49,3 +50,13 @@ After GitHub Pages deploys, play at:
 
 - Main game file: `index.html`
 - Auto deploy workflow: `.github/workflows/pages.yml`
+
+## Modem Feedback Integration
+
+The game includes a floating `Feedback` button (top-right) and sends submissions to Modem API.
+
+Optional runtime config via browser globals or `localStorage`:
+
+- `MODEM_FEEDBACK_ENDPOINT` / `localStorage.modemFeedbackEndpoint`
+- `MODEM_API_KEY` / `localStorage.modemApiKey`
+- `MODEM_PROJECT_ID` / `localStorage.modemProjectId`

--- a/index.html
+++ b/index.html
@@ -10,6 +10,22 @@ html,body{margin:0;height:100%;overflow:hidden;background:#000;font-family:"Cour
 canvas{display:block;width:100vw;height:100vh}
 #hud{position:fixed;inset:0;pointer-events:none;display:flex;justify-content:space-between;padding:12px 18px;font-size:clamp(20px,1.6vw,30px);font-weight:700;letter-spacing:.02em;text-shadow:0 0 6px #000}
 #msg{position:fixed;left:50%;top:84%;transform:translate(-50%,-50%);pointer-events:none;text-align:center;white-space:pre-line;text-shadow:0 0 8px #000;font-size:clamp(20px,1.8vw,30px)}
+#feedbackBtn{position:fixed;top:62px;right:16px;z-index:30;border:1px solid rgba(136,245,255,.6);background:rgba(8,18,35,.75);color:#dbf8ff;padding:7px 11px;font:700 14px/1 "Courier New",Consolas,monospace;border-radius:999px;cursor:pointer;backdrop-filter:blur(2px);transition:background .14s,border-color .14s}
+#feedbackBtn:hover{background:rgba(19,43,84,.85);border-color:rgba(136,245,255,.95)}
+#feedbackModal{position:fixed;inset:0;z-index:40;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.58);backdrop-filter:blur(2px)}
+#feedbackModal.open{display:flex}
+#feedbackPanel{width:min(560px,calc(100vw - 26px));background:rgba(8,13,25,.96);border:1px solid rgba(136,245,255,.4);box-shadow:0 12px 60px rgba(0,0,0,.7);padding:14px}
+#feedbackPanel h2{margin:0 0 10px;font-size:20px;letter-spacing:.03em}
+#feedbackPanel label{display:block;margin:8px 0 5px;font-size:14px;color:#bfefff}
+#feedbackPanel select,#feedbackPanel input,#feedbackPanel textarea{width:100%;border:1px solid #2f5f81;background:#050a14;color:#f4f7ff;padding:8px;font:15px/1.3 "Courier New",Consolas,monospace;box-sizing:border-box}
+#feedbackPanel textarea{min-height:120px;resize:vertical}
+#feedbackActions{display:flex;gap:10px;justify-content:flex-end;margin-top:10px}
+#feedbackActions button{border:1px solid #3d85b0;background:#0d1c36;color:#e5f9ff;padding:8px 13px;font:700 14px/1 "Courier New",Consolas,monospace;cursor:pointer}
+#feedbackActions button[type="submit"]{background:#13395f;border-color:#5dc2ff}
+#feedbackStatus{min-height:18px;font-size:13px;color:#8ed5ff;margin-top:8px}
+#feedbackStatus.err{color:#ff8c8c}
+#feedbackToast{position:fixed;left:50%;top:24px;transform:translateX(-50%);z-index:50;background:rgba(9,30,55,.96);border:1px solid rgba(136,245,255,.7);color:#dff7ff;padding:8px 14px;font:700 14px/1.2 "Courier New",Consolas,monospace;display:none}
+#feedbackToast.show{display:block}
 .k{color:var(--a)}
 </style>
 </head>
@@ -17,12 +33,42 @@ canvas{display:block;width:100vw;height:100vh}
 <canvas id="c"></canvas>
 <div id="hud"><div id="left"></div><div id="right"></div></div>
 <div id="msg"></div>
+<button id="feedbackBtn" aria-expanded="false" aria-controls="feedbackModal">Feedback</button>
+<div id="feedbackModal" aria-hidden="true">
+  <div id="feedbackPanel" role="dialog" aria-modal="true" aria-labelledby="feedbackTitle">
+    <h2 id="feedbackTitle">Send Feedback</h2>
+    <form id="feedbackForm">
+      <label for="fbType">Type</label>
+      <select id="fbType" required>
+        <option value="bug_report">Bug Report</option>
+        <option value="feature_request">Feature Request</option>
+      </select>
+      <label for="fbSummary">Title</label>
+      <input id="fbSummary" maxlength="120" placeholder="Short summary" required />
+      <label for="fbDescription">Description</label>
+      <textarea id="fbDescription" maxlength="3000" placeholder="What happened? Steps to reproduce? Expected behavior?" required></textarea>
+      <div id="feedbackActions">
+        <button type="button" id="fbCancel">Cancel</button>
+        <button type="submit">Submit</button>
+      </div>
+      <div id="feedbackStatus"></div>
+    </form>
+  </div>
+</div>
+<div id="feedbackToast" aria-live="polite"></div>
 <script>
 (()=>{
 const c=document.getElementById('c'),ctx=c.getContext('2d'),msg=document.getElementById('msg'),left=document.getElementById('left'),right=document.getElementById('right');
+const feedbackBtn=document.getElementById('feedbackBtn'),feedbackModal=document.getElementById('feedbackModal'),feedbackForm=document.getElementById('feedbackForm');
+const fbType=document.getElementById('fbType'),fbSummary=document.getElementById('fbSummary'),fbDescription=document.getElementById('fbDescription'),fbCancel=document.getElementById('fbCancel');
+const feedbackStatus=document.getElementById('feedbackStatus'),feedbackToast=document.getElementById('feedbackToast');
 let t0=0,started=0,paused=0,aud=0,keys={};
 const rnd=(a=1,b=0)=>Math.random()*(a-b)+b,cl=(v,a,b)=>v<a?a:v>b?b:v;
 let DPR=1;
+const BUILD='1.0.0-modem';
+const FEEDBACK_RATE_MS=30000;
+const MODEM={endpoint:window.MODEM_FEEDBACK_ENDPOINT||localStorage.modemFeedbackEndpoint||'https://api.modem.dev/v1/feedback',apiKey:window.MODEM_API_KEY||localStorage.modemApiKey||'',projectId:window.MODEM_PROJECT_ID||localStorage.modemProjectId||''};
+let feedbackOpen=0,feedbackBusy=0,feedbackPrevPaused=0,feedbackLastSubmit=0,toastTimer=0;
 const PLAY_W=280,PLAY_H=360;
 const VIS={shipW:44,shipH:34,enemyW:44,enemyH:34,gx:118,gy:66,playerBottom:92,beamLen:380};
 const STAGE1_SCRIPT=[
@@ -80,6 +126,67 @@ const stageTune=(s,ch)=>ch?{shotCap:0,attackCap:0,diveRate:0,coolA:99,coolB:99,g
  :{shotCap:3,attackCap:2+(s>5)+(s>10),diveRate:1.02+s*.055,coolA:4.7,coolB:2.2,globalA:1.3,globalB:.9,capChance:.28,diveShotRate:.8,aimMul:.18,aimClamp:22,aimRnd:4,bulletVy:184,bulletVyStage:4};
 const shotCap=()=>S.t?S.t.shotCap:0;
 
+function setFeedbackStatus(t='',err=0){
+ feedbackStatus.textContent=t;
+ feedbackStatus.className=err?'err':'';
+}
+function showToast(t){
+ feedbackToast.textContent=t;
+ feedbackToast.classList.add('show');
+ clearTimeout(toastTimer);
+ toastTimer=setTimeout(()=>feedbackToast.classList.remove('show'),1700);
+}
+function openFeedback(){
+ if(feedbackOpen)return;
+ feedbackPrevPaused=paused;paused=1;feedbackOpen=1;keys={};
+ feedbackModal.classList.add('open');
+ feedbackModal.setAttribute('aria-hidden','false');
+ feedbackBtn.setAttribute('aria-expanded','true');
+ setFeedbackStatus('');
+ setTimeout(()=>fbSummary.focus(),0);
+}
+function closeFeedback(force=0){
+ if(!feedbackOpen||(!force&&feedbackBusy))return;
+ feedbackOpen=0;paused=feedbackPrevPaused;
+ feedbackModal.classList.remove('open');
+ feedbackModal.setAttribute('aria-hidden','true');
+ feedbackBtn.setAttribute('aria-expanded','false');
+}
+async function submitFeedback(ev){
+ ev.preventDefault();
+ if(feedbackBusy)return;
+ const now=Date.now(),wait=FEEDBACK_RATE_MS-(now-feedbackLastSubmit);
+ if(wait>0){setFeedbackStatus(`Please wait ${Math.ceil(wait/1000)}s before sending another report.`,1);return;}
+ const type=fbType.value==='feature_request'?'feature_request':'bug_report';
+ const title=fbSummary.value.trim().replace(/\s+/g,' ');
+ const description=fbDescription.value.trim();
+ if(title.length<4){setFeedbackStatus('Title must be at least 4 characters.',1);return;}
+ if(description.length<10){setFeedbackStatus('Description must be at least 10 characters.',1);return;}
+ feedbackBusy=1;
+ setFeedbackStatus('Submitting to Modem...');
+ const payload={
+  type,title,description,
+  project_id:MODEM.projectId||undefined,
+  timestamp:new Date(now).toISOString(),
+  game:{name:'Neo Galaga Tribute',version:BUILD,url:location.href,user_agent:navigator.userAgent,language:navigator.language},
+  game_state:{stage:S.stage,score:S.score,lives:Math.max(0,S.lives+1),started:!!started,paused:!!paused,challenge:!!S.challenge}
+ };
+ const headers={'Content-Type':'application/json'};
+ if(MODEM.apiKey)headers.Authorization=`Bearer ${MODEM.apiKey}`;
+ try{
+  const r=await fetch(MODEM.endpoint,{method:'POST',headers,body:JSON.stringify(payload)});
+  if(!r.ok){const body=(await r.text().catch(()=>''))||`HTTP ${r.status}`;throw new Error(body.slice(0,140));}
+  feedbackLastSubmit=now;
+  fbType.value='bug_report';fbSummary.value='';fbDescription.value='';
+  setFeedbackStatus('Submitted. Thanks for the report.');
+  showToast('Feedback sent');
+  setTimeout(()=>closeFeedback(),240);
+ }catch(err){
+  const txt=String(err&&err.message||err||'Network error');
+  setFeedbackStatus(txt.includes('Failed to fetch')?'Network error: could not reach Modem API.':`Submit failed: ${txt}`,1);
+ }finally{feedbackBusy=0;}
+}
+
 function rs(){
  DPR=window.devicePixelRatio||1;
  c.width=innerWidth*DPR;c.height=innerHeight*DPR;ctx.setTransform(DPR,0,0,DPR,0,0);
@@ -93,7 +200,21 @@ function rs(){
 }
 addEventListener('resize',rs);
 function toggleFullscreen(){if(!document.fullscreenElement)document.documentElement.requestFullscreen?.();else document.exitFullscreen?.();}
-addEventListener('keydown',e=>{keys[e.code]=1;if(['ArrowLeft','ArrowRight','Space'].includes(e.code))e.preventDefault();if(e.code==='KeyF')toggleFullscreen();if(e.code==='KeyU')S.ultra=S.ultra?0:1;if(!started&&e.code==='Enter')start();if(started&&e.code==='KeyP')paused=!paused;if((!aud||sfx.a?.state==='suspended')&&['Enter','Space'].includes(e.code)){sfx.a?.resume?.();aud=1;}});
+feedbackBtn.addEventListener('click',openFeedback);
+fbCancel.addEventListener('click',()=>closeFeedback());
+feedbackModal.addEventListener('click',e=>{if(e.target===feedbackModal)closeFeedback();});
+feedbackForm.addEventListener('submit',submitFeedback);
+addEventListener('keydown',e=>{
+ if(e.code==='F1'||e.key==='?'){e.preventDefault();openFeedback();return;}
+ if(feedbackOpen){if(e.code==='Escape'){e.preventDefault();closeFeedback();}return;}
+ keys[e.code]=1;
+ if(['ArrowLeft','ArrowRight','Space'].includes(e.code))e.preventDefault();
+ if(e.code==='KeyF')toggleFullscreen();
+ if(e.code==='KeyU')S.ultra=S.ultra?0:1;
+ if(!started&&e.code==='Enter')start();
+ if(started&&e.code==='KeyP')paused=!paused;
+ if((!aud||sfx.a?.state==='suspended')&&['Enter','Space'].includes(e.code)){sfx.a?.resume?.();aud=1;}
+});
 addEventListener('keyup',e=>keys[e.code]=0);
 
 function makeEnemy(t,r,c,tx,ty){const boss=t==='boss';return{id:(Math.random()*1e9)|0,t,r,c,hp:boss?2:1,max:boss?2:1,x:PLAY_W/2+rnd(180,-180),y:-80-r*16,tx,ty,form:0,dive:0,vx:0,vy:0,tm:rnd(6),ph:rnd(8),cool:rnd(2.3,.8),carry:0,beam:0,beamT:0,targetX:0,targetY:0,shot:0,spawn:r*.06+c*.02,en:0,lead:null,off:0,esc:0,ch:0,miss:0};}


### PR DESCRIPTION
Implements #1 with an in-game feedback UX and API wiring.

## What was added
- Floating `Feedback` button in upper-right on all screens
- Modal with type selector, title, description, submit/cancel
- Keyboard shortcut: `F1` or `?` to open modal
- Game pause/dim behavior while modal is open
- Client-side rate limit (1 submission / 30s)
- Submission payload includes metadata (type/title/description, version, user agent, timestamp, game state)
- Success toast and friendly error handling
- README updates for control/config docs

## Notes
- Endpoint and credentials can be provided at runtime via `window.MODEM_FEEDBACK_ENDPOINT`, `window.MODEM_API_KEY`, and `window.MODEM_PROJECT_ID` (or corresponding `localStorage` keys).

Closes #1
