### PR TITLE
Codify Platinum game boundary principle

### DIFF
--- a/APPLICATIONS_ON_PLATINUM.md
+++ b/APPLICATIONS_ON_PLATINUM.md
@@ -74,9 +74,49 @@ A Platinum application should not own:
 - platform-only boot and pack-selection behavior
 - startup and wait-mode shell copy that promotes the platform or other applications
 
+## Game-To-Game Isolation Rule
+
+Applications must not depend on each other's game-specific implementation.
+
+Aurora Galactica may not be the hidden source of Galaxy Guardians mechanics,
+scoring, aliens, sound cues, visual identity, event vocabulary, or gameplay
+harness behavior. Galaxy Guardians should likewise never become a source of
+Aurora behavior. If both applications need the same thing, we should raise that
+thing into Platinum and expose it through a deliberate platform contract.
+
+Allowed reuse:
+
+- Platinum shell APIs
+- Platinum input contracts
+- Platinum audio engine capabilities
+- Platinum event/replay/session substrate
+- Platinum service adapters
+- Platinum pack schema and capability flags
+- documented platform harness helpers
+
+Disallowed reuse:
+
+- one game's scoring table inside another game
+- one game's enemy movement model inside another game
+- one game's capture, rescue, dual-fighter, challenge, flagship, escort, or
+  stage progression logic inside another game
+- one game's visual or sound identity catalog as another game's default
+- one game's application harnesses as proof of another game's behavior
+
+See also:
+
+- `/Users/steven/Documents/Codex-Test1/PLATINUM_GAME_BOUNDARY_AUDIT.md`
+
 ## Current Boundary Notes
 
 The boundary is real, but these coupling areas still deserve attention:
+
+### Direct game-to-game sharing risk
+
+The current second-game preview is safe because it is not playable, but it still
+borrows Aurora-owned tables in the mainline pack file. That must remain a
+preview-only shortcut. A playable Galaxy Guardians slice needs its own pack data
+and gameplay adapter, with any true common behavior promoted into Platinum.
 
 ### Preview pack persistence
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,6 +33,9 @@ What is still transitional:
 - some naming and compatibility residue is still Aurora-shaped
 - the game-pack contract is still practical rather than strongly versioned
 - the second application is still preview-only rather than fully playable
+- the second-game preview still borrows Aurora-owned tables while non-playable;
+  playable second-game work must either own its own game data or use Platinum
+  APIs
 
 ## Runtime Layout
 
@@ -146,6 +149,11 @@ Harness families should now be thought of in categories:
 - seam and contract harnesses
 - migration and compatibility harnesses
 
+Application/gameplay harnesses must stay game-owned. A harness that proves
+Aurora capture/rescue, challenge-stage cadence, or dual-fighter behavior does
+not prove Galaxy Guardians behavior. Shared harness helpers belong in Platinum;
+game behavior assertions belong to the owning game.
+
 The intended release rule is automation-first:
 
 - automate when the behavior is stable enough to measure
@@ -157,6 +165,8 @@ The intended release rule is automation-first:
   - `/Users/steven/Documents/Codex-Test1/PLATINUM.md`
 - application guide:
   - `/Users/steven/Documents/Codex-Test1/APPLICATIONS_ON_PLATINUM.md`
+- game boundary audit:
+  - `/Users/steven/Documents/Codex-Test1/PLATINUM_GAME_BOUNDARY_AUDIT.md`
 - platform diagrams:
   - `/Users/steven/Documents/Codex-Test1/PLATINUM_ARCHITECTURE_OVERVIEW.md`
 - testing and release discipline:

--- a/PLATINUM.md
+++ b/PLATINUM.md
@@ -42,6 +42,32 @@ It should not own:
 - Aurora challenge-stage structure
 - Aurora-specific copy, stage identity, or boss personality
 
+## Architectural Invariant: No Direct Game-To-Game Sharing
+
+Games on Platinum should not share game-specific code, rule tables, state,
+assets, mechanics, or capabilities directly with each other.
+
+If a behavior is common to more than one game, that commonality belongs in
+Platinum as a named API, interface, service, capability flag, harness substrate,
+or versioned contract. Applications may depend on Platinum contracts; they
+should not depend on another application's implementation.
+
+In practical terms:
+
+- Aurora changes must not affect Galaxy Guardians except through intentional
+  Platinum contract changes
+- Galaxy Guardians changes must not affect Aurora except through intentional
+  Platinum contract changes
+- future games must receive reusable behavior through Platinum extension points,
+  not sideways imports from Aurora or Galaxy Guardians
+- game-owned mechanics such as capture/rescue, dual-fighter mode, challenge
+  stages, flagship escorts, alien movement, scoring, visual identity, sound
+  cues, and event vocabulary stay inside the owning game pack
+
+The current audit for this boundary is:
+
+- `/Users/steven/Documents/Codex-Test1/PLATINUM_GAME_BOUNDARY_AUDIT.md`
+
 ## What Platinum Is Today
 
 Today Platinum is a real shipped platform, not a speculative refactor.
@@ -194,6 +220,9 @@ Current remaining seams to keep visible:
 - some storage and compatibility names are still Aurora-shaped even when they are effectively platform-owned
 - some debug globals and legacy naming still reflect the older single-game architecture
 - the game-pack contract is practical but not yet strongly versioned
+- the current second-game preview still borrows Aurora-owned rule and theme
+  tables while it is non-playable; those must become Galaxy Guardians-owned or
+  Platinum-owned before a playable second-game preview
 - some shell copy and application copy still need stronger structural validation so release-time regressions are caught automatically
 - the second application is still preview-only, so the contract is proven with one real game and one shell-only preview rather than two full implementations
 
@@ -316,6 +345,8 @@ of the normal release flow.
   - `/Users/steven/Documents/Codex-Test1/PLATINUM_ARCHITECTURE_OVERVIEW.md`
 - application-side separation and usage:
   - `/Users/steven/Documents/Codex-Test1/APPLICATIONS_ON_PLATINUM.md`
+- game boundary audit:
+  - `/Users/steven/Documents/Codex-Test1/PLATINUM_GAME_BOUNDARY_AUDIT.md`
 - repo technical map:
   - `/Users/steven/Documents/Codex-Test1/ARCHITECTURE.md`
 - release and testing gate discipline:

--- a/PLATINUM_ARCHITECTURE_OVERVIEW.md
+++ b/PLATINUM_ARCHITECTURE_OVERVIEW.md
@@ -64,12 +64,22 @@ Today the architecture is in this state:
 - `Galaxy Guardians` exists as a preview-only sibling application shell
 - hosted docs now need to describe the platform separately from the applications it hosts
 
+## Boundary Principle
+
+Applications do not share game-specific implementation directly. If Aurora,
+Galaxy Guardians, or a future pack needs common behavior, that behavior should
+move into Platinum as an explicit API, interface, capability, service, contract,
+or harness helper. Game-owned rules, scoring, movement, visual identity, sound
+cues, and event vocabulary stay with the owning application.
+
 ## Related Docs
 
 - canonical platform guide:
   - `/Users/steven/Documents/Codex-Test1/PLATINUM.md`
 - application-layer guide:
   - `/Users/steven/Documents/Codex-Test1/APPLICATIONS_ON_PLATINUM.md`
+- game boundary audit:
+  - `/Users/steven/Documents/Codex-Test1/PLATINUM_GAME_BOUNDARY_AUDIT.md`
 - repo technical map:
   - `/Users/steven/Documents/Codex-Test1/ARCHITECTURE.md`
 - release and testing discipline:

--- a/PLATINUM_GAME_BOUNDARY_AUDIT.md
+++ b/PLATINUM_GAME_BOUNDARY_AUDIT.md
@@ -1,0 +1,197 @@
+# Platinum Game Boundary Audit
+
+Status: `architecture-principle-and-current-main-audit`
+
+Date: 2026-04-27
+
+Use this document when deciding whether a change belongs in Platinum, Aurora
+Galactica, Galaxy Guardians, or a future game pack.
+
+## Architectural Principle
+
+Games on Platinum must not share game-specific code, rule tables, state, assets,
+or capabilities directly with each other.
+
+If two or more games need the same behavior, the behavior should be promoted
+into Platinum as a named platform API, interface, service, capability, contract,
+or harness substrate. A game may depend on that Platinum contract, but it should
+not depend on another game's implementation.
+
+This creates three hard rules:
+
+- Aurora changes must not alter Galaxy Guardians behavior except through an
+  intentional Platinum contract change.
+- Galaxy Guardians changes must not alter Aurora behavior except through an
+  intentional Platinum contract change.
+- A future game's reusable need should become a Platinum extension point rather
+  than a sideways import from Aurora or Galaxy Guardians.
+
+## Current Mainline Read
+
+Current `main` is still in a transitional but understandable state.
+
+What is safe today:
+
+- Aurora Galactica remains the only playable application.
+- Galaxy Guardians is a preview-only pack.
+- `start()` blocks non-playable packs before gameplay starts.
+- preview launch fallback restores the playable default pack.
+- pack capability flags already distinguish Aurora-only mechanics such as
+  capture/rescue, challenge stages, and dual-fighter mode.
+- the shared entity helper only attaches capture state when the active pack
+  declares `usesCaptureRescue`.
+
+What is not yet ready for a playable second game:
+
+- the pack registry and Aurora pack data still live together in
+  `src/js/13-aurora-game-pack.js`
+- the Galaxy Guardians preview pack currently reuses Aurora atmosphere, audio,
+  stage cadence, stage band, formation, challenge, frame accent, and scoring
+  tables
+- core gameplay files are still Aurora application files, not a routed
+  multi-game gameplay adapter layer
+- `src/js/90-harness.js` is still mostly an Aurora gameplay harness surface even
+  though some harness hooks are platform-facing
+- some debug and docs-preview globals still carry Aurora names
+
+That is acceptable for a shell preview. It is not acceptable for Galaxy
+Guardians `0.1` gameplay.
+
+## Coupling Inventory
+
+### Pack Registry And Pack Data
+
+Current file:
+
+- `src/js/13-aurora-game-pack.js`
+
+Current status:
+
+- contains both `AURORA_GAME_PACK` and `GALAXY_GUARDIANS_PACK`
+- exposes shared pack registry functions
+- stores Aurora rule tables and theme tables
+- lets the preview pack reuse Aurora tables while it is non-playable
+
+Required direction:
+
+- split platform registry behavior from game-owned pack definitions
+- keep Aurora tables in an Aurora-owned pack module
+- create Galaxy Guardians-owned rule, movement, audio, visual, and scoring
+  tables before its playable preview
+- reject direct reuse of another game's tables unless the reused behavior has
+  first been promoted into a Platinum contract
+
+### Gameplay Runtime
+
+Current files:
+
+- `src/js/05-player-flow.js`
+- `src/js/05-player-combat.js`
+- `src/js/06-enemy-behavior.js`
+- `src/js/07-capture-rescue.js`
+- `src/js/08-score-awards.js`
+- `src/js/09-stage-flow.js`
+- `src/js/10-gameplay.js`
+- `src/js/20-render.js`
+- `src/js/21-render-board.js`
+
+Current status:
+
+- these are still Aurora gameplay implementation files
+- they can call pack metadata, scoring, timing, and capability helpers
+- they are safe while Aurora is the only playable pack
+- they should not become the hidden runtime for a playable Galaxy Guardians
+  slice
+
+Required direction:
+
+- introduce a gameplay adapter boundary before a second playable ruleset ships
+- let Platinum call the active game's adapter through a stable interface
+- keep Aurora capture/rescue, dual fighter, challenge-stage behavior, and
+  Aurora scoring in the Aurora adapter
+- keep Galaxy Guardians scout-wave, flagship, escort, single-shot, dive, and
+  scoring behavior in the Galaxy Guardians adapter
+
+### Capability Flags
+
+Current status:
+
+- capability flags exist and are already useful in the picker and entity model
+- Galaxy Guardians preview explicitly disables:
+  - `usesChallengeStages`
+  - `usesCaptureRescue`
+  - `usesDualFighterMode`
+
+Required direction:
+
+- keep capability flags declarative
+- make gameplay boot and gameplay adapters enforce them
+- add cross-pack harnesses proving disabled capabilities cannot leak into a
+  pack's runtime
+
+### Preview Fallback
+
+Current files:
+
+- `src/js/05-player-flow.js`
+- `src/js/00-boot.js`
+- `src/js/15-game-picker.js`
+
+Current status:
+
+- non-playable packs cannot start gameplay
+- preview selection is not persisted as the durable playable pack
+- launching from a preview-only state returns to the playable default
+
+Required direction:
+
+- keep this as Platinum behavior
+- when there is more than one playable game, replace single default fallback
+  assumptions with an explicit "first playable/default playable pack" policy
+
+### Harnesses
+
+Current file:
+
+- `src/js/90-harness.js`
+
+Current status:
+
+- contains both platform-facing hooks and Aurora-specific gameplay controls
+- still uses Aurora-shaped capture, challenge, rescue, and dual-fighter setup
+  helpers
+
+Required direction:
+
+- split platform harness hooks from application harness hooks
+- require each playable game to provide its own behavior harness family
+- add seam harnesses for cross-pack isolation
+
+## Guardians 0.1 Gate
+
+Before Galaxy Guardians can be treated as a real playable preview, the branch
+must prove:
+
+- no Aurora capture/rescue behavior can run in Guardians
+- no Aurora dual-fighter state can run in Guardians
+- no Aurora challenge-stage cadence can run in Guardians
+- Guardians has its own alien catalog, visual identity, sound cue catalog,
+  movement model, scoring table, and event vocabulary
+- any shared input, shell, audio engine, event capture, replay, or service
+  behavior is reached through Platinum APIs rather than Aurora code
+- Aurora harnesses still pass after Guardians gameplay is added
+- Guardians harnesses fail if Aurora-only mechanics appear in the Guardians
+  runtime
+
+## Recommended Next Code Slice
+
+The next implementation slice should be a platform boundary slice, not a large
+gameplay slice:
+
+- create a platform-owned pack registry module
+- split Aurora pack data out of the registry
+- add a placeholder Galaxy Guardians pack-data module that does not reuse Aurora
+  rule tables for future playable fields
+- add a cross-pack isolation harness for disabled capabilities
+- update the architecture docs after the split
+


### PR DESCRIPTION
## Summary

- codifies the Platinum invariant that games cannot share game-specific implementation directly
- adds a boundary audit for current Aurora / Galaxy Guardians coupling on main
- links the audit from Platinum, application, architecture, and overview docs

## Verification

- npm run build
- npm run harness:check:platinum-pack-boot
- git diff --check

## Notes

This is documentation and architecture guidance only; no runtime code changes.