### PR TITLE
Add Guardians adapter skeleton gate

### DIFF
--- a/APPLICATIONS_ON_PLATINUM.md
+++ b/APPLICATIONS_ON_PLATINUM.md
@@ -45,6 +45,8 @@ Right now it proves:
 - pack-owned preview content for the picker and preview modal
 - pack-owned placeholder timing, audio, visual, cadence, layout, and scoring
   tables that do not directly borrow Aurora tables
+- a disabled, evidence-gated gameplay adapter skeleton with its own initial
+  state shape
 - safe fallback to `Aurora Galactica` when a player tries to launch gameplay
 
 It does not yet prove:
@@ -52,7 +54,7 @@ It does not yet prove:
 - a second full gameplay ruleset
 - a second complete scoring and stage-flow implementation
 - a second complete application harness family
-- a registered gameplay adapter
+- a public registered gameplay adapter
 
 That is intentional.
 
@@ -118,10 +120,11 @@ The boundary is real, but these coupling areas still deserve attention:
 
 The current second-game preview is safe because it is not playable, and its
 preview pack now owns placeholder data instead of borrowing Aurora-owned tables.
-It also has no gameplay adapter, so it cannot start through Aurora's gameplay
-implementation by accident. A playable Galaxy Guardians slice still needs
-measured, game-specific pack data and its own gameplay adapter, with any true
-common behavior promoted into Platinum.
+It also has no public gameplay adapter, so it cannot start through Aurora's
+gameplay implementation by accident. Its disabled adapter skeleton records the
+first state-shape contract for the future scout-wave slice, but a playable
+Galaxy Guardians slice still needs measured, game-specific pack data and its own
+registered adapter, with any true common behavior promoted into Platinum.
 
 ### Preview pack persistence
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,6 +84,8 @@ What is still transitional:
   - `/Users/steven/Documents/Codex-Test1/src/js/13-aurora-game-pack.js`
 - Galaxy Guardians preview pack metadata:
   - `/Users/steven/Documents/Codex-Test1/src/js/13-galaxy-guardians-game-pack.js`
+- Galaxy Guardians disabled gameplay adapter skeleton:
+  - `/Users/steven/Documents/Codex-Test1/src/js/13-galaxy-guardians-gameplay-adapter.js`
 - shared entity model used by packs:
   - `/Users/steven/Documents/Codex-Test1/src/js/14-entity-model.js`
 - Aurora render orchestration:
@@ -165,6 +167,10 @@ Pack-boundary harness:
   verifies that Aurora is the only registered gameplay adapter, Galaxy
   Guardians cannot start gameplay without its own adapter, and preview launch
   fallback starts through the Aurora adapter.
+- `/Users/steven/Documents/Codex-Test1/tools/harness/check-guardians-adapter-skeleton.js`
+  verifies that the Galaxy Guardians skeleton exists, stays disabled, exposes a
+  single-shot scout-wave state shape, and fails closed until measured evidence
+  exists.
 
 Application/gameplay harnesses must stay game-owned. A harness that proves
 Aurora capture/rescue, challenge-stage cadence, or dual-fighter behavior does

--- a/PLATINUM_GAME_BOUNDARY_AUDIT.md
+++ b/PLATINUM_GAME_BOUNDARY_AUDIT.md
@@ -49,6 +49,8 @@ What is not yet ready for a playable second game:
 - the pack registry is now separated from Aurora and Galaxy Guardians pack data
 - the gameplay adapter registry now registers Aurora as the only playable
   gameplay adapter
+- Galaxy Guardians now has a disabled adapter skeleton that is evidence-gated
+  and not registered as playable
 - the Galaxy Guardians preview pack now owns placeholder atmosphere, audio,
   timing, stage cadence, stage band, formation, challenge, frame accent, and
   scoring tables while it remains non-playable
@@ -69,6 +71,7 @@ Current files:
 
 - `src/js/13-aurora-game-pack.js`
 - `src/js/13-galaxy-guardians-game-pack.js`
+- `src/js/13-galaxy-guardians-gameplay-adapter.js`
 - `src/js/13-game-pack-registry.js`
 - `src/js/13-gameplay-adapter-registry.js`
 
@@ -79,6 +82,9 @@ Current status:
 - `src/js/13-galaxy-guardians-game-pack.js` stores preview-owned placeholder
   rule, timing, theme, audio, visual, and scoring tables plus
   `GALAXY_GUARDIANS_PACK`
+- `src/js/13-galaxy-guardians-gameplay-adapter.js` stores a disabled
+  Galaxy Guardians adapter skeleton with a single-shot scout-wave state shape
+  and explicit Aurora-capability exclusions
 - `src/js/13-game-pack-registry.js` exposes shared pack registry functions and
   active-pack runtime helpers
 - `src/js/13-gameplay-adapter-registry.js` exposes shared gameplay adapter
@@ -88,6 +94,9 @@ Current status:
   Guardians does not directly share game-owned table references with Aurora
 - `npm run harness:check:gameplay-adapter-boundaries` verifies that Galaxy
   Guardians cannot start gameplay until it owns an adapter
+- `npm run harness:check:guardians-adapter-skeleton` verifies that the disabled
+  skeleton exists, fails closed, and does not carry Aurora capture, dual,
+  challenge, scoring, or enemy-family state
 
 Required direction:
 
@@ -213,17 +222,21 @@ The first platform boundary slice is now in place:
 - gameplay adapter registry that starts only registered playable adapters
 - gameplay adapter boundary harness proving Galaxy Guardians preview falls back
   to Aurora instead of routing through Aurora directly
+- disabled Galaxy Guardians adapter skeleton with a first scout-wave state
+  contract and evidence gate
+- Guardians adapter skeleton harness proving the disabled skeleton cannot start
+  gameplay and does not include Aurora-only state
 - architecture docs updated after the split
 
 ## Recommended Next Code Slice
 
-The next implementation slice should begin shaping the Galaxy Guardians `0.1`
-adapter, but keep it non-public until measured rules exist:
+The next implementation slice should feed measured Galaxian reference data into
+the disabled Galaxy Guardians adapter skeleton:
 
-- define the minimal adapter state and rendering hooks that a second game must
-  own
-- add a disabled Galaxy Guardians adapter skeleton only when it cannot start
-  public gameplay
-- wire the first measured scout-wave data into that skeleton
-- add a contract harness that fails if Galaxy Guardians uses Aurora capture,
-  challenge, dual-fighter, or scoring functions by default
+- extract the first scout-wave formation, dive, flagship, escort, firing, and
+  scoring facts from the promoted Galaxian references
+- replace placeholder skeleton profile values with measured values and source
+  artifact links
+- add a semantic event vocabulary for the skeleton state transitions
+- add a contract harness that fails if measured Galaxy Guardians state uses
+  Aurora capture, challenge, dual-fighter, or scoring functions by default

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "harness:check:stage1-late-parity": "node tools/harness/check-stage1-late-clear-parity.js",
     "harness:check:stage2-carryover": "node tools/harness/check-stage2-carryover-parity.js",
     "harness:check:gameplay-adapter-boundaries": "node tools/harness/check-gameplay-adapter-boundaries.js",
+    "harness:check:guardians-adapter-skeleton": "node tools/harness/check-guardians-adapter-skeleton.js",
     "harness:check:pack-registry-boundaries": "node tools/harness/check-pack-registry-boundaries.js",
     "harness:check:platinum-pack-boot": "node tools/harness/check-platinum-pack-boot.js",
     "harness:build:evidence-cycle-dashboard": "node tools/harness/build-evidence-cycle-dashboard.js",

--- a/src/js/13-galaxy-guardians-gameplay-adapter.js
+++ b/src/js/13-galaxy-guardians-gameplay-adapter.js
@@ -1,0 +1,60 @@
+// Disabled Galaxy Guardians gameplay adapter skeleton for the first owned 0.1 slice.
+
+const GALAXY_GUARDIANS_ADAPTER_FORBIDDEN_AURORA_CAPABILITIES=Object.freeze({
+ usesCaptureRescue:0,
+ usesDualFighterMode:0,
+ usesChallengeStages:0,
+ usesAuroraScoring:0,
+ usesAuroraEnemyFamilies:0
+});
+
+const GALAXY_GUARDIANS_SCOUT_WAVE_PROFILE=Object.freeze({
+ id:'scout-wave-preview',
+ evidenceState:'placeholder-awaiting-measured-galaxian-reference',
+ playerFireMode:'single-shot',
+ formationModel:'rack-with-independent-dives',
+ flagshipModel:'flagship-with-escort-pressure',
+ wrapThreatModel:'planned',
+ firstWave:Object.freeze({
+  formationRows:5,
+  flagshipSlots:2,
+  escortSlots:6,
+  scoutSlots:30,
+  entryStyle:'staggered-top-entry-placeholder',
+  diveStyle:'curving-independent-dive-placeholder'
+ })
+});
+
+function createGalaxyGuardiansInitialState(opts={}){
+ return Object.freeze({
+  gameKey:GALAXY_GUARDIANS_PACK.metadata.gameKey,
+  adapterState:'disabled-skeleton',
+  stage:Math.max(1,+opts.stage||1),
+  score:0,
+  lives:Math.max(1,Math.min(9,+opts.ships||3)),
+  fireMode:GALAXY_GUARDIANS_SCOUT_WAVE_PROFILE.playerFireMode,
+  formationModel:GALAXY_GUARDIANS_SCOUT_WAVE_PROFILE.formationModel,
+  flagshipModel:GALAXY_GUARDIANS_SCOUT_WAVE_PROFILE.flagshipModel,
+  captureRescue:null,
+  dualFighter:null,
+  challengeStage:null,
+  auroraScoring:null,
+  entities:Object.freeze([]),
+  bullets:Object.freeze([]),
+  events:Object.freeze([])
+ });
+}
+
+const GALAXY_GUARDIANS_GAMEPLAY_ADAPTER_SKELETON=Object.freeze({
+ gameKey:GALAXY_GUARDIANS_PACK.metadata.gameKey,
+ label:'Galaxy Guardians disabled gameplay skeleton',
+ enabled:0,
+ publicPlayable:0,
+ evidenceRequired:1,
+ profile:GALAXY_GUARDIANS_SCOUT_WAVE_PROFILE,
+ forbiddenAuroraCapabilities:GALAXY_GUARDIANS_ADAPTER_FORBIDDEN_AURORA_CAPABILITIES,
+ createInitialState:createGalaxyGuardiansInitialState,
+ start(){
+  throw new Error('Galaxy Guardians gameplay adapter is disabled until measured 0.1 scout-wave evidence exists.');
+ }
+});

--- a/src/js/13-gameplay-adapter-registry.js
+++ b/src/js/13-gameplay-adapter-registry.js
@@ -10,6 +10,10 @@ const GAMEPLAY_ADAPTER_REGISTRY=Object.freeze({
  [AURORA_GAMEPLAY_ADAPTER.gameKey]:AURORA_GAMEPLAY_ADAPTER
 });
 
+const GAMEPLAY_ADAPTER_SKELETON_REGISTRY=Object.freeze({
+ [GALAXY_GUARDIANS_GAMEPLAY_ADAPTER_SKELETON.gameKey]:GALAXY_GUARDIANS_GAMEPLAY_ADAPTER_SKELETON
+});
+
 function gameplayAdapterKey(packOrKey=currentGamePack()){
  if(typeof packOrKey==='string')return packOrKey;
  return packOrKey?.metadata?.gameKey||DEFAULT_GAME_PACK_KEY;
@@ -19,9 +23,18 @@ function availableGameplayAdapters(){
  return GAMEPLAY_ADAPTER_REGISTRY;
 }
 
+function availableGameplayAdapterSkeletons(){
+ return GAMEPLAY_ADAPTER_SKELETON_REGISTRY;
+}
+
 function getGameplayAdapter(packOrKey=currentGamePack()){
  const key=gameplayAdapterKey(packOrKey);
  return GAMEPLAY_ADAPTER_REGISTRY[key]||null;
+}
+
+function getGameplayAdapterSkeleton(packOrKey=currentGamePack()){
+ const key=gameplayAdapterKey(packOrKey);
+ return GAMEPLAY_ADAPTER_SKELETON_REGISTRY[key]||null;
 }
 
 function currentGameplayAdapter(){
@@ -63,7 +76,9 @@ function start(){
 }
 
 window.availableGameplayAdapters=availableGameplayAdapters;
+window.availableGameplayAdapterSkeletons=availableGameplayAdapterSkeletons;
 window.getGameplayAdapter=getGameplayAdapter;
+window.getGameplayAdapterSkeleton=getGameplayAdapterSkeleton;
 window.currentGameplayAdapter=currentGameplayAdapter;
 window.gamePackHasPlayableAdapter=gamePackHasPlayableAdapter;
 window.currentGamePackHasPlayableAdapter=currentGamePackHasPlayableAdapter;

--- a/tools/harness/check-guardians-adapter-skeleton.js
+++ b/tools/harness/check-guardians-adapter-skeleton.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+const { withHarnessPage } = require('./browser-check-util');
+
+function fail(message, payload){
+  console.error(message);
+  if(payload) console.error(JSON.stringify(payload, null, 2));
+  process.exit(1);
+}
+
+async function main(){
+  const result = await withHarnessPage({ skipStart: true, stage: 1, ships: 3, seed: 42719 }, async ({ page }) => page.evaluate(() => {
+    const playableAdapters = typeof availableGameplayAdapters === 'function' ? availableGameplayAdapters() : {};
+    const skeletons = typeof availableGameplayAdapterSkeletons === 'function' ? availableGameplayAdapterSkeletons() : {};
+    const skeleton = skeletons['galaxy-guardians-preview'];
+    const initialState = skeleton?.createInitialState?.({ stage: 2, ships: 4 }) || null;
+    let startError = '';
+    try{
+      skeleton?.start?.();
+    }catch(err){
+      startError = String(err?.message || err);
+    }
+    return {
+      playableAdapterKeys:Object.keys(playableAdapters),
+      skeletonKeys:Object.keys(skeletons),
+      skeleton:Object.freeze({
+        gameKey:skeleton?.gameKey || '',
+        enabled:skeleton?.enabled,
+        publicPlayable:skeleton?.publicPlayable,
+        evidenceRequired:skeleton?.evidenceRequired,
+        fireMode:skeleton?.profile?.playerFireMode || '',
+        formationModel:skeleton?.profile?.formationModel || '',
+        flagshipModel:skeleton?.profile?.flagshipModel || '',
+        forbiddenAuroraCapabilities:skeleton?.forbiddenAuroraCapabilities || null
+      }),
+      initialState,
+      startError,
+      started:window.__galagaHarness__.state().started,
+      currentPack:typeof currentGamePackKey === 'function' ? currentGamePackKey() : ''
+    };
+  }));
+
+  if(result.playableAdapterKeys.includes('galaxy-guardians-preview')){
+    fail('Galaxy Guardians skeleton leaked into the playable adapter registry', result);
+  }
+  if(!result.playableAdapterKeys.includes('aurora-galactica')){
+    fail('Aurora playable adapter is missing while checking the Guardians skeleton', result);
+  }
+  if(!result.skeletonKeys.includes('galaxy-guardians-preview')){
+    fail('Galaxy Guardians adapter skeleton is missing', result);
+  }
+  if(result.skeleton.enabled !== 0 || result.skeleton.publicPlayable !== 0 || result.skeleton.evidenceRequired !== 1){
+    fail('Galaxy Guardians skeleton is not explicitly disabled and evidence-gated', result);
+  }
+  if(result.skeleton.fireMode !== 'single-shot'){
+    fail('Galaxy Guardians skeleton does not preserve the single-shot baseline', result);
+  }
+  if(!result.skeleton.formationModel.includes('rack') || !result.skeleton.flagshipModel.includes('flagship')){
+    fail('Galaxy Guardians skeleton is missing its scout-wave/flagship model labels', result);
+  }
+  const forbidden = result.skeleton.forbiddenAuroraCapabilities || {};
+  for(const key of ['usesCaptureRescue','usesDualFighterMode','usesChallengeStages','usesAuroraScoring','usesAuroraEnemyFamilies']){
+    if(forbidden[key] !== 0) fail(`Galaxy Guardians skeleton did not explicitly disable ${key}`, result);
+  }
+  if(!result.initialState || result.initialState.gameKey !== 'galaxy-guardians-preview'){
+    fail('Galaxy Guardians skeleton did not create its own initial state shape', result);
+  }
+  for(const key of ['captureRescue','dualFighter','challengeStage','auroraScoring']){
+    if(result.initialState[key] !== null) fail(`Galaxy Guardians initial state unexpectedly includes ${key}`, result);
+  }
+  if(result.initialState.fireMode !== 'single-shot' || result.initialState.stage !== 2 || result.initialState.lives !== 4){
+    fail('Galaxy Guardians initial state did not preserve configured skeleton state', result);
+  }
+  if(!result.startError.includes('disabled until measured 0.1 scout-wave evidence exists')){
+    fail('Galaxy Guardians skeleton start did not fail closed with the expected evidence gate', result);
+  }
+  if(result.started){
+    fail('Galaxy Guardians skeleton started gameplay while disabled', result);
+  }
+
+  console.log(JSON.stringify({
+    ok:true,
+    playableAdapterKeys:result.playableAdapterKeys,
+    skeletonKeys:result.skeletonKeys,
+    fireMode:result.initialState.fireMode,
+    startGate:result.startError
+  }, null, 2));
+}
+
+main().catch(err => fail(err && err.stack || String(err)));


### PR DESCRIPTION
## Summary
- Adds a disabled Galaxy Guardians gameplay adapter skeleton with an explicit single-shot scout-wave state shape.
- Keeps Galaxy Guardians out of the playable adapter registry while exposing skeleton lookup APIs for contract checks.
- Adds `harness:check:guardians-adapter-skeleton` to prove the skeleton is disabled, evidence-gated, does not carry Aurora capture/dual/challenge/scoring state, and fails closed if started.
- Updates architecture and boundary docs with the completed skeleton gate and next measured-reference step.

## Verification
- `npm run build`
- `npm run harness:check:guardians-adapter-skeleton`
- `npm run harness:check:gameplay-adapter-boundaries`
- `npm run harness:check:pack-registry-boundaries`
- `npm run harness:check:platinum-pack-boot`
- `node tools/harness/check-game-picker-shell.js`
- `git diff --check`