### PR TITLE
Add Guardians dev playable preview

### DIFF
--- a/APPLICATIONS_ON_PLATINUM.md
+++ b/APPLICATIONS_ON_PLATINUM.md
@@ -50,9 +50,13 @@ Right now it proves:
 - a dev-only visible preview board renderer that drives the Guardians-owned
   scout-wave runtime, visual catalog, and audio cue catalog without registering
   a playable adapter
+- a development-only playable-preview adapter that routes keyboard movement,
+  single-shot fire, life loss, reset, and game-over flow into the
+  Guardians-owned runtime while keeping the public playable adapter disabled
 - a source-manifested Galaxian reference profile with three local source videos,
   contact sheets, and waveforms
-- safe fallback to `Aurora Galactica` when a player tries to launch gameplay
+- safe public-pack behavior because `Galaxy Guardians` still has no public
+  registered gameplay adapter
 
 It does not yet prove:
 
@@ -60,6 +64,7 @@ It does not yet prove:
 - a second complete scoring and stage-flow implementation
 - a second complete application harness family
 - a public registered gameplay adapter
+- release-ready public playability
 
 That is intentional.
 
@@ -134,13 +139,19 @@ adapter, with any true common behavior promoted into Platinum.
 
 ### Preview pack persistence
 
-Preview-only applications must not become a durable trap state.
+Preview-only applications must not become a durable trap state. During
+development a preview application may also expose an explicit dev-only playable
+adapter so we can test the runtime slice before public playability.
 
 Current expected behavior:
 
 - preview application can be opened
 - shell can show its promo surface
-- `Enter` should fall back to a playable application when preview-only content cannot start gameplay
+- `Enter` should fall back to a playable application when preview-only content
+  cannot start gameplay
+- `Enter` may start a dev-only preview only when the development build exposes
+  an explicit dev-preview adapter and the pack still remains publicly
+  non-playable
 
 ### Front-door copy ownership
 
@@ -227,8 +238,9 @@ signal palette. The renderer is now registered through a Platinum game-board
 renderer registry, so the top-level render loop no longer branches on a
 specific game by name.
 
-The next application proof is turning that runtime model into a dev-only
-playable slice that includes:
+The next application proof is maturing the first dev-only playable slice. It
+now has the initial lifecycle path, but the behavior is still intentionally
+development-scoped until the measured 0.1 scout-wave evidence is stronger.
 
 - formation rack
 - dives
@@ -237,6 +249,18 @@ playable slice that includes:
 - single-shot constraint
 - wrap-around threat
 - life loss and game over flow
+
+Current development-only playable-preview coverage:
+
+- `src/js/13-galaxy-guardians-gameplay-adapter.js` owns the dev-only start and
+  update adapter for `Galaxy Guardians`
+- `src/js/13-galaxy-guardians-runtime.js` owns the runtime state, events, player
+  shot, life-loss, reset, and game-over mechanics
+- `src/js/13-gameplay-adapter-registry.js` keeps public playable adapters and
+  dev-preview adapters in separate registries
+- `tools/harness/check-galaxy-guardians-playable-preview.js` proves keyboard
+  fire, life loss, reset, game over, owned audio cue IDs, and public-adapter
+  isolation
 
 That is enough to test the platform without prematurely shipping a second game.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,9 @@ What is still transitional:
 
 - some naming and compatibility residue is still Aurora-shaped
 - the game-pack contract is still practical rather than strongly versioned
-- the second application is still preview-only rather than fully playable
+- the second application is still public-preview-only rather than fully
+  playable; it now has a development-only playable-preview adapter for local
+  runtime proof
 - the second-game preview now owns placeholder pack data, but playable
   second-game work still needs measured game data and a gameplay adapter rather
   than Aurora gameplay reuse
@@ -88,6 +90,8 @@ What is still transitional:
   - `/Users/steven/Documents/Codex-Test1/src/js/13-galaxy-guardians-game-pack.js`
 - Galaxy Guardians disabled gameplay adapter skeleton:
   - `/Users/steven/Documents/Codex-Test1/src/js/13-galaxy-guardians-gameplay-adapter.js`
+- Galaxy Guardians dev-only scout-wave runtime:
+  - `/Users/steven/Documents/Codex-Test1/src/js/13-galaxy-guardians-runtime.js`
 - shared entity model used by packs:
   - `/Users/steven/Documents/Codex-Test1/src/js/14-entity-model.js`
 - Aurora board and sprite rendering:
@@ -166,9 +170,10 @@ Pack-boundary harness:
   tables, stays non-playable, and does not inherit Aurora challenge cadence,
   challenge layout, or reference timings.
 - `tools/harness/check-gameplay-adapter-boundaries.js`
-  verifies that Aurora is the only registered gameplay adapter, Galaxy
-  Guardians cannot start gameplay without its own adapter, and preview launch
-  fallback starts through the Aurora adapter.
+  verifies that Aurora is the only registered public gameplay adapter, Galaxy
+  Guardians remains blocked from public playability, and the explicit
+  development-only preview adapter starts only the Guardians-owned runtime
+  slice.
 - `tools/harness/check-guardians-adapter-skeleton.js`
   verifies that the Galaxy Guardians skeleton exists, stays disabled, exposes a
   single-shot scout-wave state shape, cites the promoted event log, and fails
@@ -185,6 +190,10 @@ Pack-boundary harness:
   flagship/escort/scout roles, single-shot firing, promoted event emission,
   Guardians-owned scoring, Guardians-owned visual/audio catalog bindings, and
   no Aurora capture/challenge/dual-fighter state.
+- `tools/harness/check-galaxy-guardians-playable-preview.js`
+  verifies the development-only Galaxy Guardians playable-preview adapter:
+  keyboard fire routing, life loss, reset, game over, owned audio cue IDs, and
+  isolation from the public playable adapter registry.
 - `tools/harness/check-compact-cabinet-rails.js`
   verifies that both side-frame icon rails remain visible and inside the
   cabinet frame at the compact in-app browser scale, and that the Galaxy

--- a/PLATINUM_GAME_BOUNDARY_AUDIT.md
+++ b/PLATINUM_GAME_BOUNDARY_AUDIT.md
@@ -36,9 +36,11 @@ modules.
 What is safe today:
 
 - Aurora Galactica remains the only playable application.
-- Galaxy Guardians is a preview-only pack.
+- Galaxy Guardians is a public preview-only pack, with a development-only
+  playable-preview adapter for local runtime proof.
 - `start()` blocks non-playable packs before gameplay starts.
-- preview launch fallback restores the playable default pack.
+- preview launch fallback restores the playable default pack when no explicit
+  development preview adapter exists.
 - pack capability flags already distinguish Aurora-only mechanics such as
   capture/rescue, challenge stages, and dual-fighter mode.
 - the shared entity helper only attaches capture state when the active pack
@@ -47,8 +49,10 @@ What is safe today:
 What is not yet ready for a playable second game:
 
 - the pack registry is now separated from Aurora and Galaxy Guardians pack data
-- the gameplay adapter registry now registers Aurora as the only playable
-  gameplay adapter
+- the gameplay adapter registry now registers Aurora as the only public
+  playable gameplay adapter
+- the dev-preview gameplay adapter registry separately exposes the local-only
+  Galaxy Guardians playable preview path in development builds
 - Galaxy Guardians now has a disabled adapter skeleton that is evidence-gated
   and not registered as playable
 - the skeleton now cites a three-source Galaxian reference profile with contact
@@ -92,11 +96,16 @@ Current status:
   active-pack runtime helpers
 - `src/js/13-gameplay-adapter-registry.js` exposes shared gameplay adapter
   registration and start routing; Aurora is currently the only registered
-  playable adapter
+  public playable adapter, while Galaxy Guardians has a separate
+  development-only preview adapter
 - `npm run harness:check:pack-registry-boundaries` verifies that Galaxy
   Guardians does not directly share game-owned table references with Aurora
 - `npm run harness:check:gameplay-adapter-boundaries` verifies that Galaxy
-  Guardians cannot start gameplay until it owns an adapter
+  Guardians remains blocked from the public playable adapter registry while its
+  explicit development-only preview adapter can start the owned runtime slice
+- `npm run harness:check:galaxy-guardians-playable-preview` verifies the
+  Guardians development preview adapter, keyboard fire routing, life loss,
+  reset, game over, owned audio cue IDs, and public-adapter isolation
 - `npm run harness:check:guardians-adapter-skeleton` verifies that the disabled
   skeleton exists, fails closed, and does not carry Aurora capture, dual,
   challenge, scoring, or enemy-family state
@@ -178,15 +187,18 @@ Current files:
 
 Current status:
 
-- non-playable packs cannot start gameplay
+- non-playable packs cannot start public gameplay
 - preview selection is not persisted as the durable playable pack
-- launching from a preview-only state returns to the playable default
+- launching from a preview-only state returns to the playable default unless an
+  explicit development-only preview adapter is present in a development build
 
 Required direction:
 
 - keep this as Platinum behavior
 - when there is more than one playable game, replace single default fallback
   assumptions with an explicit "first playable/default playable pack" policy
+- keep dev-preview adapters separate from public playable adapters so local
+  proofs cannot accidentally become release playability
 
 ### Harnesses
 
@@ -250,6 +262,9 @@ The first platform boundary slice is now in place:
   and player interceptor identities plus a separate sound cue catalog for start,
   formation pulse, single-shot firing, dive pressure, escort joins, hits,
   wrap/return, and future player loss
+- dev-only Galaxy Guardians playable-preview adapter with keyboard movement,
+  single-shot fire, life loss, reset, and game-over lifecycle routed into the
+  Guardians-owned runtime while public playability remains disabled
 - visible dev-only Galaxy Guardians preview renderer that draws the owned
   scout-wave runtime, visual catalog IDs, audio cue IDs, and preview HUD while
   keeping the pack non-playable
@@ -262,14 +277,15 @@ The first platform boundary slice is now in place:
 
 ## Recommended Next Code Slice
 
-The next implementation slice should refine the visible dev runtime into a
-dev-only playable preview:
+The next implementation slice should refine the dev-only playable preview into
+a stronger measured 0.1 scout-wave candidate:
 
 - extract frame-level formation, dive, flagship, escort, firing, and scoring
   facts from the promoted windows and source videos
-- add life loss, game over, and reset flow without importing Aurora rules
-- route player input into the Guardians runtime behind an explicit dev-only
-  playable-preview gate while keeping the public pack non-playable
+- tune life loss, game over, reset, and player invulnerability windows against
+  reference footage without importing Aurora rules
+- keep player input routed into the Guardians runtime behind the explicit
+  dev-only playable-preview gate while the public pack remains non-playable
 - convert broad semantic event windows into tighter runtime timing bands
 - add a contract harness that fails if measured Galaxy Guardians state uses
   Aurora capture, challenge, dual-fighter, or scoring functions by default

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "harness:check:stage2-carryover": "node tools/harness/check-stage2-carryover-parity.js",
     "harness:check:galaxian-reference-profile": "node tools/harness/check-galaxian-reference-profile.js",
     "harness:check:galaxy-guardians-runtime-slice": "node tools/harness/check-galaxy-guardians-runtime-slice.js",
+    "harness:check:galaxy-guardians-playable-preview": "node tools/harness/check-galaxy-guardians-playable-preview.js",
     "harness:check:gameplay-adapter-boundaries": "node tools/harness/check-gameplay-adapter-boundaries.js",
     "harness:check:guardians-adapter-skeleton": "node tools/harness/check-guardians-adapter-skeleton.js",
     "harness:check:compact-cabinet-rails": "node tools/harness/check-compact-cabinet-rails.js",

--- a/src/js/00-boot.js
+++ b/src/js/00-boot.js
@@ -2033,7 +2033,9 @@ addEventListener('keydown',e=>{
   }
  }
  if(!started&&e.code==='Enter'){
-  const packCanStart=typeof currentGamePackHasPlayableAdapter==='function'
+  const packCanStart=typeof currentGamePackCanStart==='function'
+   ? currentGamePackCanStart()
+   : typeof currentGamePackHasPlayableAdapter==='function'
    ? currentGamePackHasPlayableAdapter()
    : (typeof currentGamePackPlayable!=='function'||currentGamePackPlayable());
   if(!packCanStart){

--- a/src/js/10-gameplay.js
+++ b/src/js/10-gameplay.js
@@ -10,7 +10,7 @@ function ex(x,y,n=10,col='#fff'){
 }
 
 
-function update(dt){
+function updateAuroraGameplay(dt){
  if((!started&&!S.attract)||paused)return;
  logCarryDebugState();
  recShotT-=dt;
@@ -208,4 +208,17 @@ function update(dt){
   return
  }
  for(let i=S.fx.length-1;i>=0;i--){const f=S.fx[i];f.t-=dt;f.x+=f.vx*dt;f.y+=f.vy*dt;f.vx*=.985;f.vy*=.985;if(f.t<=0)S.fx.splice(i,1)}
+}
+
+function update(dt){
+ if(
+  typeof currentGamePackHasPlayableAdapter==='function'
+  && !currentGamePackHasPlayableAdapter()
+  && typeof currentGamePackHasDevPreviewAdapter==='function'
+  && currentGamePackHasDevPreviewAdapter()
+  && typeof updateActiveGamePack==='function'
+ ){
+  return updateActiveGamePack(dt);
+ }
+ return updateAuroraGameplay(dt);
 }

--- a/src/js/13-galaxy-guardians-gameplay-adapter.js
+++ b/src/js/13-galaxy-guardians-gameplay-adapter.js
@@ -57,7 +57,10 @@ const GALAXY_GUARDIANS_REFERENCE_PROFILE=Object.freeze({
   'escort_join',
   'player_shot_fired',
   'player_shot_resolved',
-  'enemy_wrap_or_return'
+  'enemy_wrap_or_return',
+  'player_lost',
+  'game_over',
+  'wave_reset'
  ])
 });
 
@@ -119,3 +122,140 @@ const GALAXY_GUARDIANS_GAMEPLAY_ADAPTER_SKELETON=Object.freeze({
   throw new Error('Galaxy Guardians gameplay adapter is disabled until measured 0.1 scout-wave evidence exists.');
  }
 });
+
+let GALAXY_GUARDIANS_ACTIVE_DEV_STATE=null;
+
+function galaxyGuardiansDevPreviewAllowed(){
+ return typeof BUILD_INFO!=='undefined'
+  && String(BUILD_INFO.releaseChannel||'development').toLowerCase()==='development'
+  && !!GALAXY_GUARDIANS_RUNTIME_PROFILE.devPlayable
+  && !GALAXY_GUARDIANS_RUNTIME_PROFILE.publicPlayable;
+}
+
+function syncGalaxyGuardiansShellState(state){
+ if(!state)return;
+ S.score=state.score|0;
+ S.stage=state.stage|0;
+ S.lives=Math.max(0,(state.lives|0)-1);
+ S.stageClock=+state.t||0;
+ S.simT=+state.t||0;
+ S.challenge=0;
+ S.liveCount=state.aliens.filter(alien=>alien.hp>0).length;
+ if(state.gameOver){
+  gameOverHtml=`<span class="gameOverTitle">GALAXY GUARDIANS</span><span class="gameOverSub">DEV PREVIEW COMPLETE</span><span class="gameOverLine">SCORE ${String(state.score|0).padStart(6,'0')}</span><span class="gameOverHint">CHOOSE GAME TO RETURN TO AURORA</span>`;
+ }
+}
+
+function closeGalaxyGuardiansDevOverlays(){
+ if(typeof closeAccountPanel==='function')closeAccountPanel();
+ if(typeof closeLeaderboardPanel==='function')closeLeaderboardPanel();
+ if(typeof closeSettings==='function')closeSettings();
+ if(typeof closeHelp==='function'&&helpOpen)closeHelp(1);
+ if(typeof closeFeedback==='function'&&feedbackOpen)closeFeedback(1);
+ if(typeof closeGamePreview==='function')closeGamePreview(1);
+ if(typeof closeMoviePanel==='function'&&typeof isMoviePanelOpen==='function'&&isMoviePanelOpen())closeMoviePanel(1);
+}
+
+function startGalaxyGuardiansDevPreview(cfg={}){
+ if(!galaxyGuardiansDevPreviewAllowed()){
+  showToast('Galaxy Guardians playable preview is available only in development builds.');
+  return false;
+ }
+ if(typeof clearRuntimeLoopFault==='function')clearRuntimeLoopFault();
+ stopAttractLoop();
+ try{document.activeElement?.blur?.()}catch{}
+ if(typeof resetActiveInputState==='function')resetActiveInputState('guardians_dev_preview_start');
+ closeGalaxyGuardiansDevOverlays();
+ resetSession('guardians_dev_preview_start');
+ autoExportedSessionId='';
+ const testCfg=saveTestCfg();
+ setSeed(localStorage.getItem(SEED_PREF_KEY)||0);
+ aud=1;AC().resume?.();
+ gameOverHtml='';gameOverState=null;
+ started=1;paused=0;
+ Object.assign(S,{
+  score:0,
+  lives:Math.max(0,(+cfg.ships||+testCfg.ships||3)-1),
+  stage:Math.max(1,+cfg.stage||+testCfg.stage||1),
+  shake:0,
+  banner:0,
+  bannerTxt:'',
+  bannerMode:'',
+  bannerSub:'',
+  alertT:0,
+  alertTxt:'',
+  challenge:0,
+  forceChallenge:0,
+  liveCount:0,
+  recoverT:0,
+  attackGapT:0,
+  nextStageT:0,
+  postChallengeT:0,
+  pendingStage:0,
+  transitionMode:'',
+  sequenceT:0,
+  sequenceMode:'',
+  attract:0,
+  simT:0,
+  stageClock:0
+ });
+ GALAXY_GUARDIANS_ACTIVE_DEV_STATE=createGalaxyGuardiansRuntimeState({
+  stage:S.stage,
+  ships:Math.max(1,+cfg.ships||+testCfg.ships||3),
+  seed:(+cfg.seed>>>0)||(+localStorage.getItem(SEED_PREF_KEY)>>>0)||42719
+ });
+ syncGalaxyGuardiansShellState(GALAXY_GUARDIANS_ACTIVE_DEV_STATE);
+ if(typeof resetHarnessFrameClock==='function')resetHarnessFrameClock();
+ if(typeof syncPauseUi==='function')syncPauseUi();
+ logEvent('game_start',{gameKey:GALAXY_GUARDIANS_PACK.metadata.gameKey,devPreview:1});
+ startRunRecording();
+ sfx.playCue('gameStart',{phase:'stage'});
+ msg.textContent='';
+ c?.focus?.();
+ return true;
+}
+
+function galaxyGuardiansInputFromKeys(){
+ return {
+  left:!!(keys.ArrowLeft||keys.KeyA||keys.KeyZ),
+  right:!!(keys.ArrowRight||keys.KeyD||keys.KeyC),
+  fire:!!keys.Space
+ };
+}
+
+function updateGalaxyGuardiansDevPreview(dt){
+ if(!GALAXY_GUARDIANS_ACTIVE_DEV_STATE)return;
+ stepGalaxyGuardiansRuntime(GALAXY_GUARDIANS_ACTIVE_DEV_STATE,dt,galaxyGuardiansInputFromKeys());
+ syncGalaxyGuardiansShellState(GALAXY_GUARDIANS_ACTIVE_DEV_STATE);
+ if(GALAXY_GUARDIANS_ACTIVE_DEV_STATE.gameOver){
+  started=0;
+  paused=0;
+  if(typeof syncPauseUi==='function')syncPauseUi();
+  stopRunRecording();
+ }
+}
+
+function currentGalaxyGuardiansDevPreviewState(){
+ return GALAXY_GUARDIANS_ACTIVE_DEV_STATE;
+}
+
+function summarizeGalaxyGuardiansDevPreview(){
+ return GALAXY_GUARDIANS_ACTIVE_DEV_STATE
+  ? summarizeGalaxyGuardiansRuntime(GALAXY_GUARDIANS_ACTIVE_DEV_STATE)
+  : null;
+}
+
+const GALAXY_GUARDIANS_DEV_PREVIEW_ADAPTER=Object.freeze({
+ gameKey:GALAXY_GUARDIANS_PACK.metadata.gameKey,
+ label:'Galaxy Guardians dev-only playable preview',
+ enabled:1,
+ devOnly:1,
+ publicPlayable:0,
+ start:startGalaxyGuardiansDevPreview,
+ update:updateGalaxyGuardiansDevPreview,
+ snapshot:summarizeGalaxyGuardiansDevPreview
+});
+
+window.galaxyGuardiansDevPreviewAllowed=galaxyGuardiansDevPreviewAllowed;
+window.currentGalaxyGuardiansDevPreviewState=currentGalaxyGuardiansDevPreviewState;
+window.summarizeGalaxyGuardiansDevPreview=summarizeGalaxyGuardiansDevPreview;

--- a/src/js/13-galaxy-guardians-runtime.js
+++ b/src/js/13-galaxy-guardians-runtime.js
@@ -56,7 +56,10 @@ const GALAXY_GUARDIANS_RUNTIME_PROFILE=Object.freeze({
   'escort_join',
   'player_shot_fired',
   'player_shot_resolved',
-  'enemy_wrap_or_return'
+  'enemy_wrap_or_return',
+  'player_lost',
+  'game_over',
+  'wave_reset'
  ]),
  rules:Object.freeze({
   playfieldWidth:280,
@@ -65,6 +68,8 @@ const GALAXY_GUARDIANS_RUNTIME_PROFILE=Object.freeze({
   singleShotCooldown:.72,
   firstScoutDiveDelay:2.2,
   flagshipEscortDelay:6.4,
+  playerRespawnDelay:1.35,
+  playerInvulnerability:.95,
   wrapThreatModel:'bottom-exit-or-return-explicit-preview-rule',
   formation:Object.freeze({
    flagshipSlots:2,
@@ -130,6 +135,8 @@ function createGalaxyGuardiansRuntimeState(opts={}){
   score:0,
   lives,
   t:0,
+  gameOver:0,
+  resetT:0,
   seed,
   rngSeed:seed,
   diveIndex:0,
@@ -139,7 +146,9 @@ function createGalaxyGuardiansRuntimeState(opts={}){
    x:GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.playfieldWidth/2,
    y:GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.playfieldHeight-28,
    shot:null,
-   cooldown:0
+   cooldown:0,
+   inv:0,
+   visible:1
   },
   aliens:createGalaxyGuardiansFormation(),
   enemyShots:[],
@@ -192,10 +201,45 @@ function startGuardiansDive(state,alien,escortCount=0){
 
 function fireGuardiansPlayerShot(state){
  const p=state.player;
+ if(state.gameOver||state.resetT>0||!p.visible)return false;
  if(p.shot||p.cooldown>0)return false;
  p.shot={x:p.x,y:p.y-8,vy:-178,active:1};
  p.cooldown=GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.singleShotCooldown;
  guardiansRuntimeEvent(state,'player_shot_fired',{x:+p.x.toFixed(2),y:+p.shot.y.toFixed(2),audioCue:GALAXY_GUARDIANS_PACK.audioCueCatalog.playerShot.id,visualId:GALAXY_GUARDIANS_RUNTIME_PROFILE.playerVisualId});
+ return true;
+}
+
+function resetGalaxyGuardiansWave(state,reason='wave_reset'){
+ state.aliens=createGalaxyGuardiansFormation();
+ state.enemyShots.length=0;
+ state.player.shot=null;
+ state.player.x=GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.playfieldWidth/2;
+ state.player.y=GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.playfieldHeight-28;
+ state.player.cooldown=0;
+ state.player.inv=GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.playerInvulnerability;
+ state.player.visible=1;
+ state.diveIndex=0;
+ state.nextDiveAt=state.t+GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.firstScoutDiveDelay;
+ state.nextFlagshipAt=state.t+GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.flagshipEscortDelay;
+ guardiansRuntimeEvent(state,'wave_reset',{reason,aliens:state.aliens.length});
+}
+
+function loseGalaxyGuardiansPlayer(state,cause='collision'){
+ if(state.gameOver||state.resetT>0||state.player.inv>0)return false;
+ state.lives=Math.max(0,state.lives-1);
+ state.player.visible=0;
+ state.player.shot=null;
+ state.resetT=state.lives>0?GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.playerRespawnDelay:0;
+ guardiansRuntimeEvent(state,'player_lost',{
+  cause,
+  lives:state.lives,
+  audioCue:GALAXY_GUARDIANS_PACK.audioCueCatalog.playerLoss.id,
+  visualId:GALAXY_GUARDIANS_RUNTIME_PROFILE.playerVisualId
+ });
+ if(state.lives<=0){
+  state.gameOver=1;
+  guardiansRuntimeEvent(state,'game_over',{score:state.score,stage:state.stage});
+ }
  return true;
 }
 
@@ -214,9 +258,17 @@ function stepGalaxyGuardiansRuntime(state,dt=.016,input={}){
  const rules=GALAXY_GUARDIANS_RUNTIME_PROFILE.rules;
  const p=state.player;
  const move=(input.right?1:0)-(input.left?1:0);
- state.t+=Math.max(0,Math.min(.2,+dt||0));
- p.x=Math.max(12,Math.min(rules.playfieldWidth-12,p.x+move*112*dt));
+ dt=Math.max(0,Math.min(.2,+dt||0));
+ state.t+=dt;
  p.cooldown=Math.max(0,p.cooldown-dt);
+ p.inv=Math.max(0,(+p.inv||0)-dt);
+ if(state.gameOver)return state;
+ if(state.resetT>0){
+  state.resetT=Math.max(0,state.resetT-dt);
+  if(!state.resetT)resetGalaxyGuardiansWave(state,'life_reset');
+  return state;
+ }
+ p.x=Math.max(12,Math.min(rules.playfieldWidth-12,p.x+move*112*dt));
  if(input.fire)fireGuardiansPlayerShot(state);
  if(state.t>=state.nextDiveAt){
   const alien=pickGuardiansAlien(state,'scout')||pickGuardiansAlien(state);
@@ -246,6 +298,9 @@ function stepGalaxyGuardiansRuntime(state,dt=.016,input={}){
    alien.x=alien.rackX;
    alien.y=alien.rackY;
    guardiansRuntimeEvent(state,'enemy_wrap_or_return',{id:alien.id,role:alien.role,visualId:alien.visualId,audioCue:GALAXY_GUARDIANS_PACK.audioCueCatalog.wrapReturn.id});
+  }
+  if(alien.mode==='diving'&&p.visible&&p.inv<=0&&Math.abs(alien.x-p.x)<=10&&Math.abs(alien.y-p.y)<=10){
+   loseGalaxyGuardiansPlayer(state,`alien_${alien.role}_collision`);
   }
  }
  if(p.shot){
@@ -288,6 +343,10 @@ function summarizeGalaxyGuardiansRuntime(state){
   alienCount:state.aliens.filter(alien=>alien.hp>0).length,
   liveRoles:counts,
   hasPlayerShot:!!state.player.shot,
+  playerVisible:!!state.player.visible,
+  playerInv:+(+state.player.inv||0).toFixed(3),
+  resetT:+(+state.resetT||0).toFixed(3),
+  gameOver:!!state.gameOver,
   eventTypes:Array.from(new Set(state.events.map(event=>event.type))),
   visualIds:Array.from(new Set(state.aliens.filter(alien=>alien.hp>0).map(alien=>alien.visualId))),
   audioCueIds:Array.from(new Set(state.events.map(event=>event.audioCue).filter(Boolean))),
@@ -299,3 +358,5 @@ window.GALAXY_GUARDIANS_RUNTIME_PROFILE=GALAXY_GUARDIANS_RUNTIME_PROFILE;
 window.createGalaxyGuardiansRuntimeState=createGalaxyGuardiansRuntimeState;
 window.stepGalaxyGuardiansRuntime=stepGalaxyGuardiansRuntime;
 window.summarizeGalaxyGuardiansRuntime=summarizeGalaxyGuardiansRuntime;
+window.loseGalaxyGuardiansPlayer=loseGalaxyGuardiansPlayer;
+window.resetGalaxyGuardiansWave=resetGalaxyGuardiansWave;

--- a/src/js/13-gameplay-adapter-registry.js
+++ b/src/js/13-gameplay-adapter-registry.js
@@ -14,6 +14,10 @@ const GAMEPLAY_ADAPTER_SKELETON_REGISTRY=Object.freeze({
  [GALAXY_GUARDIANS_GAMEPLAY_ADAPTER_SKELETON.gameKey]:GALAXY_GUARDIANS_GAMEPLAY_ADAPTER_SKELETON
 });
 
+const DEV_PREVIEW_GAMEPLAY_ADAPTER_REGISTRY=Object.freeze({
+ [GALAXY_GUARDIANS_DEV_PREVIEW_ADAPTER.gameKey]:GALAXY_GUARDIANS_DEV_PREVIEW_ADAPTER
+});
+
 function gameplayAdapterKey(packOrKey=currentGamePack()){
  if(typeof packOrKey==='string')return packOrKey;
  return packOrKey?.metadata?.gameKey||DEFAULT_GAME_PACK_KEY;
@@ -27,6 +31,10 @@ function availableGameplayAdapterSkeletons(){
  return GAMEPLAY_ADAPTER_SKELETON_REGISTRY;
 }
 
+function availableDevPreviewGameplayAdapters(){
+ return DEV_PREVIEW_GAMEPLAY_ADAPTER_REGISTRY;
+}
+
 function getGameplayAdapter(packOrKey=currentGamePack()){
  const key=gameplayAdapterKey(packOrKey);
  return GAMEPLAY_ADAPTER_REGISTRY[key]||null;
@@ -37,8 +45,24 @@ function getGameplayAdapterSkeleton(packOrKey=currentGamePack()){
  return GAMEPLAY_ADAPTER_SKELETON_REGISTRY[key]||null;
 }
 
+function developmentGameplayPreviewAllowed(){
+ return typeof BUILD_INFO!=='undefined'
+  && String(BUILD_INFO.releaseChannel||'development').toLowerCase()==='development';
+}
+
+function getDevPreviewGameplayAdapter(packOrKey=currentGamePack()){
+ if(!developmentGameplayPreviewAllowed())return null;
+ const key=gameplayAdapterKey(packOrKey);
+ const adapter=DEV_PREVIEW_GAMEPLAY_ADAPTER_REGISTRY[key]||null;
+ return adapter&&adapter.enabled&&adapter.devOnly&&typeof adapter.start==='function'?adapter:null;
+}
+
 function currentGameplayAdapter(){
  return getGameplayAdapter(currentGamePackKey());
+}
+
+function currentDevPreviewGameplayAdapter(){
+ return getDevPreviewGameplayAdapter(currentGamePackKey());
 }
 
 function gamePackHasPlayableAdapter(packOrKey=currentGamePack()){
@@ -51,12 +75,31 @@ function currentGamePackHasPlayableAdapter(){
  return gamePackHasPlayableAdapter(currentGamePack());
 }
 
+function gamePackHasDevPreviewAdapter(packOrKey=currentGamePack()){
+ return !!getDevPreviewGameplayAdapter(packOrKey);
+}
+
+function currentGamePackHasDevPreviewAdapter(){
+ return gamePackHasDevPreviewAdapter(currentGamePack());
+}
+
+function currentGamePackCanStart(){
+ return currentGamePackHasPlayableAdapter()||currentGamePackHasDevPreviewAdapter();
+}
+
 function firstPlayableGamePackWithAdapter(){
  return Object.values(availableGamePacks()).find(pack=>gamePackHasPlayableAdapter(pack))||null;
 }
 
 function startActiveGamePack(){
  const adapter=currentGameplayAdapter();
+ const devPreviewAdapter=currentDevPreviewGameplayAdapter();
+ if(currentGamePackHasPlayableAdapter()){
+  return adapter.start();
+ }
+ if(devPreviewAdapter){
+  return devPreviewAdapter.start();
+ }
  if(!currentGamePackHasPlayableAdapter()){
   const preview=typeof currentGamePackPreview==='function'?currentGamePackPreview():null;
   const fallback=firstPlayableGamePackWithAdapter();
@@ -68,7 +111,15 @@ function startActiveGamePack(){
   showToast(preview?.launchFallbackToast||'Selected game does not have a playable adapter in this build.');
   return false;
  }
- return adapter.start();
+ return false;
+}
+
+function updateActiveGamePack(dt){
+ const adapter=currentGameplayAdapter();
+ const devPreviewAdapter=currentDevPreviewGameplayAdapter();
+ if(currentGamePackHasPlayableAdapter()&&adapter&&typeof adapter.update==='function')return adapter.update(dt);
+ if(devPreviewAdapter&&typeof devPreviewAdapter.update==='function')return devPreviewAdapter.update(dt);
+ return null;
 }
 
 function start(){
@@ -77,10 +128,17 @@ function start(){
 
 window.availableGameplayAdapters=availableGameplayAdapters;
 window.availableGameplayAdapterSkeletons=availableGameplayAdapterSkeletons;
+window.availableDevPreviewGameplayAdapters=availableDevPreviewGameplayAdapters;
 window.getGameplayAdapter=getGameplayAdapter;
 window.getGameplayAdapterSkeleton=getGameplayAdapterSkeleton;
+window.getDevPreviewGameplayAdapter=getDevPreviewGameplayAdapter;
 window.currentGameplayAdapter=currentGameplayAdapter;
+window.currentDevPreviewGameplayAdapter=currentDevPreviewGameplayAdapter;
 window.gamePackHasPlayableAdapter=gamePackHasPlayableAdapter;
 window.currentGamePackHasPlayableAdapter=currentGamePackHasPlayableAdapter;
+window.gamePackHasDevPreviewAdapter=gamePackHasDevPreviewAdapter;
+window.currentGamePackHasDevPreviewAdapter=currentGamePackHasDevPreviewAdapter;
+window.currentGamePackCanStart=currentGamePackCanStart;
 window.firstPlayableGamePackWithAdapter=firstPlayableGamePackWithAdapter;
 window.startActiveGamePack=startActiveGamePack;
+window.updateActiveGamePack=updateActiveGamePack;

--- a/src/js/15-game-picker.js
+++ b/src/js/15-game-picker.js
@@ -45,11 +45,12 @@ function renderGamePicker(){
   const caps=describePackCaps(pack);
   const flagHtml=caps.length?`<div class="gamePickerCardFlags">${caps.map(label=>`<span class="gamePickerFlag">${label}</span>`).join('')}</div>`:'';
   const playable=pack.metadata?.playable!==0&&pack.metadata?.playable!==false;
-  const actionLabel=isActive?'Selected':(playable?'Select Game':'Preview Sneak Peek');
+  const devPlayable=typeof gamePackHasDevPreviewAdapter==='function'&&gamePackHasDevPreviewAdapter(pack);
+  const actionLabel=isActive?'Selected':(playable?'Select Game':devPlayable?'Select Dev Preview':'Preview Sneak Peek');
   const previewLine=pack.preview?.cardLine||'Shell preview only while gameplay integration is still in progress';
   const disabled=isActive?' disabled':'';
   const selectedTheme=typeof selectedShellThemeForPack==='function'?selectedShellThemeForPack(pack,pack.metadata?.gameKey||''):null;
-  return `<div class="gamePickerCard${isActive?' isActive':''}"><span class="gamePickerCardTitle">${pack.metadata?.title||pack.metadata?.gameKey||'Game Pack'}</span><span class="gamePickerCardMeta">${pack.frontDoor?.featureLine||'Platform pack preview'}</span><span class="gamePickerCardMeta">${playable?'Playable in the current runtime':previewLine}</span><span class="gamePickerCardMeta">Preferred shell theme: ${selectedTheme?.label||'Default'}</span>${flagHtml}<button class="gamePickerCardAction" data-pack-key="${pack.metadata?.gameKey||''}"${disabled}>${actionLabel}</button></div>`;
+  return `<div class="gamePickerCard${isActive?' isActive':''}"><span class="gamePickerCardTitle">${pack.metadata?.title||pack.metadata?.gameKey||'Game Pack'}</span><span class="gamePickerCardMeta">${pack.frontDoor?.featureLine||'Platform pack preview'}</span><span class="gamePickerCardMeta">${playable?'Playable in the current runtime':devPlayable?'Dev-only playable preview in this development runtime':previewLine}</span><span class="gamePickerCardMeta">Preferred shell theme: ${selectedTheme?.label||'Default'}</span>${flagHtml}<button class="gamePickerCardAction" data-pack-key="${pack.metadata?.gameKey||''}"${disabled}>${actionLabel}</button></div>`;
  }).join('');
  gamePickerStatus.textContent=started
   ? 'Finish the current run before switching to a different game pack.'
@@ -93,16 +94,17 @@ function chooseGamePack(key=''){
  const playable=typeof gamePackHasPlayableAdapter==='function'
   ? gamePackHasPlayableAdapter(nextPack)
   : (typeof packIsPlayable==='function'?packIsPlayable(nextPack):(nextPack?.metadata?.playable!==0&&nextPack?.metadata?.playable!==false));
+ const devPlayable=typeof gamePackHasDevPreviewAdapter==='function'&&gamePackHasDevPreviewAdapter(nextPack);
  installGamePack(key,{persist:playable?1:0});
  if(!started&&typeof draw==='function')draw();
  renderGamePicker();
- const canStart=typeof currentGamePackHasPlayableAdapter==='function'?currentGamePackHasPlayableAdapter():currentGamePackPlayable();
+ const canStart=typeof currentGamePackCanStart==='function'?currentGamePackCanStart():typeof currentGamePackHasPlayableAdapter==='function'?currentGamePackHasPlayableAdapter():currentGamePackPlayable();
  if(!canStart){
   closeGamePicker(1);
   if(typeof openGamePreview==='function')openGamePreview();
  }else{
   closeGamePicker(1);
-  showToast(`${currentGamePack().metadata?.title||'Game pack'} selected.`);
+  showToast(devPlayable?`${currentGamePack().metadata?.title||'Game pack'} dev preview selected. Press Enter to start.`:`${currentGamePack().metadata?.title||'Game pack'} selected.`);
  }
 }
 

--- a/src/js/22-galaxy-guardians-preview-renderer.js
+++ b/src/js/22-galaxy-guardians-preview-renderer.js
@@ -134,9 +134,9 @@ function drawGalaxyGuardiansPreviewHud(summary){
  ctx.fillStyle='#dff7ff';
  ctx.fillText(String(summary.score||0).padStart(6,'0'),48,16);
  ctx.fillStyle='#ffdf6f';
- ctx.fillText('GUARDIANS DEV PREVIEW',76,PLAY_H-26);
+ ctx.fillText(summary.gameOver?'GUARDIANS GAME OVER':'GUARDIANS DEV PREVIEW',76,PLAY_H-26);
  ctx.fillStyle='#7bd6ff';
- ctx.fillText('SINGLE SHOT  FLAGSHIP ESCORTS  WRAP THREAT',32,PLAY_H-15);
+ ctx.fillText(summary.gameOver?'PRESS CHOOSE GAME FOR CABINET SELECT':'SINGLE SHOT  FLAGSHIP ESCORTS  WRAP THREAT',32,PLAY_H-15);
  ctx.restore();
 }
 
@@ -159,8 +159,11 @@ function stepGalaxyGuardiansPreviewState(now){
 }
 
 function drawGalaxyGuardiansPreviewBoard({ox,oy,scale,dx,dy}){
+ const activeState=typeof currentGalaxyGuardiansDevPreviewState==='function'
+  ? currentGalaxyGuardiansDevPreviewState()
+  : null;
  const now=performance.now();
- const state=stepGalaxyGuardiansPreviewState(now);
+ const state=activeState||stepGalaxyGuardiansPreviewState(now);
  const summary=summarizeGalaxyGuardiansRuntime(state);
  ctx.setTransform(1,0,0,1,0,0);
  ctx.clearRect(0,0,c.width,c.height);
@@ -175,7 +178,7 @@ function drawGalaxyGuardiansPreviewBoard({ox,oy,scale,dx,dy}){
  const starfield=typeof syncStarfieldProfile==='function'?syncStarfieldProfile({frontDoor:1,attractPhase:'guardians-preview'}):null;
  drawGalaxyGuardiansPreviewBackdrop(t);
  for(const alien of state.aliens)if(alien.hp>0)drawGalaxyGuardiansAlien(alien,t);
- drawGalaxyGuardiansPlayer(state.player);
+ if(state.player.visible!==false)drawGalaxyGuardiansPlayer(state.player);
  drawGalaxyGuardiansPreviewHud(summary);
  ctx.restore();
  ctx.setTransform(1,0,0,1,0,0);
@@ -201,7 +204,9 @@ registerGameBoardRenderer(GALAXY_GUARDIANS_PACK.metadata.gameKey,{
  previewOnly:true,
  canDraw(){
   const playable=typeof currentGamePackHasPlayableAdapter==='function'&&currentGamePackHasPlayableAdapter();
-  return shouldDrawGalaxyGuardiansPreviewBoard()&&(!started||!playable);
+  const devPreview=typeof currentGalaxyGuardiansDevPreviewState==='function'
+   && !!currentGalaxyGuardiansDevPreviewState();
+  return shouldDrawGalaxyGuardiansPreviewBoard()&&(!started||!playable||devPreview);
  },
  draw:drawGalaxyGuardiansPreviewBoard
 });

--- a/src/js/90-harness.js
+++ b/src/js/90-harness.js
@@ -729,6 +729,22 @@ window.__galagaHarness__={
  renderState(){
   return window.__platinumRenderDebug||window.__auroraRenderDebug||{carryDraws:[]};
  },
+ guardiansState(){
+  return typeof summarizeGalaxyGuardiansDevPreview==='function'
+   ? summarizeGalaxyGuardiansDevPreview()
+   : null;
+ },
+ forceGuardiansPlayerLoss(cause='harness_guardians_loss'){
+  const state=typeof currentGalaxyGuardiansDevPreviewState==='function'
+   ? currentGalaxyGuardiansDevPreviewState()
+   : null;
+  if(!state||typeof loseGalaxyGuardiansPlayer!=='function')return null;
+  loseGalaxyGuardiansPlayer(state,cause);
+  if(typeof updateActiveGamePack==='function')updateActiveGamePack(0);
+  return typeof summarizeGalaxyGuardiansDevPreview==='function'
+   ? summarizeGalaxyGuardiansDevPreview()
+   : null;
+ },
  redraw(){
   if(typeof draw==='function')draw();
   return this.renderState();

--- a/tools/harness/check-galaxy-guardians-playable-preview.js
+++ b/tools/harness/check-galaxy-guardians-playable-preview.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+const { withHarnessPage, waitForHarness } = require('./browser-check-util');
+
+function fail(message, payload){
+  console.error(message);
+  if(payload) console.error(JSON.stringify(payload, null, 2));
+  process.exit(1);
+}
+
+async function main(){
+  const result = await withHarnessPage({ skipStart: true, stage: 1, ships: 2, seed: 1979 }, async ({ page }) => {
+    await page.evaluate(() => {
+      installGamePack('galaxy-guardians-preview');
+      getDevPreviewGameplayAdapter('galaxy-guardians-preview').start({ stage: 1, ships: 2, seed: 1979 });
+    });
+
+    const launched = await waitForHarness(page, () => {
+      const state = window.__platinumHarness__.state();
+      const guardians = window.__platinumHarness__.guardiansState();
+      if(!state.started || !guardians) return null;
+      return {
+        state,
+        guardians,
+        packKey: currentGamePackKey(),
+        publicAdapter: currentGamePackHasPlayableAdapter(),
+        devAdapter: currentGamePackHasDevPreviewAdapter(),
+        publicPlayable: currentGamePackPlayable(),
+        snapshotGameKey: window.__platinumHarness__.snapshot().gameKey || ''
+      };
+    }, 1800, 40);
+
+    await page.keyboard.down('Space');
+    await page.evaluate(() => window.__platinumHarness__.advanceFor(.12, { step: 1/60 }));
+    await page.keyboard.up('Space');
+
+    const afterShot = await page.evaluate(() => ({
+      guardians: window.__platinumHarness__.guardiansState(),
+      state: window.__platinumHarness__.state()
+    }));
+
+    const firstLoss = await page.evaluate(() => window.__platinumHarness__.forceGuardiansPlayerLoss('harness_first_loss'));
+    await page.evaluate(() => window.__platinumHarness__.advanceFor(1.55, { step: 1/60 }));
+
+    const afterReset = await page.evaluate(() => ({
+      guardians: window.__platinumHarness__.guardiansState(),
+      state: window.__platinumHarness__.state()
+    }));
+
+    await page.evaluate(() => window.__platinumHarness__.advanceFor(1.05, { step: 1/60 }));
+    const secondLoss = await page.evaluate(() => window.__platinumHarness__.forceGuardiansPlayerLoss('harness_final_loss'));
+
+    const final = await page.evaluate(() => {
+      const guardians = window.__platinumHarness__.guardiansState();
+      const state = window.__platinumHarness__.state();
+      return {
+        guardians,
+        state,
+        packKey: currentGamePackKey(),
+        snapshotGameKey: window.__platinumHarness__.snapshot().gameKey || ''
+      };
+    });
+
+    return { launched, afterShot, firstLoss, afterReset, secondLoss, final };
+  });
+
+  if(result.launched.packKey !== 'galaxy-guardians-preview' || result.launched.snapshotGameKey !== 'galaxy-guardians-preview'){
+    fail('Galaxy Guardians playable preview did not launch as the active pack', result);
+  }
+  if(result.launched.publicPlayable !== false || result.launched.publicAdapter !== false || result.launched.devAdapter !== true){
+    fail('Galaxy Guardians playable preview crossed the public gameplay adapter boundary', result);
+  }
+  if(result.launched.guardians.publicPlayable !== 0 || result.launched.guardians.devPlayable !== 1){
+    fail('Galaxy Guardians runtime summary is not marked dev-only', result);
+  }
+  if(result.launched.guardians.alienCount !== 38 || result.launched.guardians.liveRoles.flagship !== 2){
+    fail('Galaxy Guardians playable preview did not start from the expected scout-wave rack', result);
+  }
+  if(!result.afterShot.guardians.eventTypes.includes('player_shot_fired')){
+    fail('Galaxy Guardians playable preview did not route player fire input into the runtime', result);
+  }
+  if(!result.afterShot.guardians.hasPlayerShot && !result.afterShot.guardians.eventTypes.includes('player_shot_resolved')){
+    fail('Galaxy Guardians single-shot runtime did not keep or resolve the fired player shot', result);
+  }
+  if(!result.firstLoss || !result.firstLoss.eventTypes.includes('player_lost') || result.firstLoss.lives !== 1){
+    fail('Galaxy Guardians first life-loss flow did not decrement runtime lives', result);
+  }
+  if(result.firstLoss.gameOver || result.firstLoss.playerVisible){
+    fail('Galaxy Guardians first life-loss flow should hide the player without ending the game', result);
+  }
+  if(!result.afterReset.guardians.eventTypes.includes('wave_reset') || !result.afterReset.guardians.playerVisible || result.afterReset.guardians.alienCount !== 38){
+    fail('Galaxy Guardians life-reset flow did not restore the scout-wave rack and player', result);
+  }
+  if(!result.secondLoss || !result.secondLoss.eventTypes.includes('game_over') || !result.secondLoss.gameOver){
+    fail('Galaxy Guardians final life-loss flow did not emit game over', result);
+  }
+  if(result.final.state.started){
+    fail('Galaxy Guardians dev preview stayed in active gameplay after game over', result);
+  }
+  for(const cueId of ['guardians-player-single-shot','guardians-player-loss']){
+    if(!result.final.guardians.audioCueIds.includes(cueId)){
+      fail(`Galaxy Guardians playable preview did not emit owned audio cue ${cueId}`, result);
+    }
+  }
+  for(const forbiddenName of ['capture','dual','challenge','boss']){
+    if(result.final.guardians.visualIds.some(id => String(id).includes(forbiddenName))){
+      fail(`Galaxy Guardians playable preview leaked Aurora visual naming: ${forbiddenName}`, result);
+    }
+  }
+
+  console.log(JSON.stringify({
+    ok:true,
+    packKey:result.final.packKey,
+    score:result.final.guardians.score,
+    lives:result.final.guardians.lives,
+    gameOver:result.final.guardians.gameOver,
+    eventTypes:result.final.guardians.eventTypes,
+    audioCueIds:result.final.guardians.audioCueIds
+  }, null, 2));
+}
+
+main().catch(err => fail(err && err.stack || String(err)));

--- a/tools/harness/check-galaxy-guardians-runtime-slice.js
+++ b/tools/harness/check-galaxy-guardians-runtime-slice.js
@@ -17,6 +17,7 @@ async function main(){
     window.stepGalaxyGuardiansRuntime(state, .016, { fire: true });
     const afterSecondShotCount = state.events.filter(event => event.type === 'player_shot_fired').length;
     const secondShotBlocked = afterSecondShotCount === afterFirstShotCount;
+    state.player.inv = 999;
     for(let i=0;i<520;i++){
       window.stepGalaxyGuardiansRuntime(state, 1/60, {
         left: i%180 < 90,
@@ -29,6 +30,14 @@ async function main(){
     const pack = window.getGamePack ? window.getGamePack('galaxy-guardians-preview') : null;
     const visualCatalog = pack?.alienVisualCatalog || {};
     const audioCueCatalog = pack?.audioCueCatalog || {};
+    const timingState = window.createGalaxyGuardiansRuntimeState({ stage: 1, ships: 3, seed: 42719 });
+    timingState.player.inv = 999;
+    for(let i=0;i<430;i++){
+      window.stepGalaxyGuardiansRuntime(timingState, 1/60, {});
+    }
+    const firstDiveEvent = timingState.events.find(event => event.type === 'alien_dive_start');
+    const flagshipDiveEvent = timingState.events.find(event => event.type === 'flagship_dive_start');
+    const escortJoinEvent = timingState.events.find(event => event.type === 'escort_join');
     return {
       profile,
       initial,
@@ -41,6 +50,14 @@ async function main(){
       runtimeVisualCatalogKeys: Object.keys(profile?.visualCatalog || {}),
       runtimeAudioCueCatalogKeys: Object.keys(profile?.audioCueCatalog || {}),
       playerVisualId: profile?.playerVisualId || '',
+      timing: {
+        firstScoutDiveDelay: profile?.rules?.firstScoutDiveDelay,
+        flagshipEscortDelay: profile?.rules?.flagshipEscortDelay,
+        singleShotCooldown: profile?.rules?.singleShotCooldown,
+        firstDiveT: firstDiveEvent?.t,
+        flagshipDiveT: flagshipDiveEvent?.t,
+        escortJoinT: escortJoinEvent?.t
+      },
       playableAdapterKeys: Object.keys(playableAdapters),
       forbidden: state.forbiddenAuroraCapabilities,
       hasAuroraState: ['captureRescue','dualFighter','challengeStage','auroraScoring'].some(key => Object.prototype.hasOwnProperty.call(state, key))
@@ -92,6 +109,15 @@ async function main(){
   if(!result.firstShot || !result.secondShotBlocked){
     fail('Galaxy Guardians runtime did not enforce the single-shot player fire model', result);
   }
+  if(Math.abs(result.timing.firstDiveT - result.timing.firstScoutDiveDelay) > .08){
+    fail('Galaxy Guardians runtime first scout dive timing drifted outside the first timing pass band', result);
+  }
+  if(Math.abs(result.timing.flagshipDiveT - result.timing.flagshipEscortDelay) > .08 || Math.abs(result.timing.escortJoinT - result.timing.flagshipDiveT) > .001){
+    fail('Galaxy Guardians runtime flagship/escort timing drifted outside the first timing pass band', result);
+  }
+  if(Math.abs(result.timing.singleShotCooldown - .72) > .001){
+    fail('Galaxy Guardians runtime single-shot cooldown drifted from the first timing pass baseline', result);
+  }
   for(const eventName of ['formation_entry_start','formation_entry_settle','formation_rack_complete','alien_dive_start','flagship_dive_start','escort_join','player_shot_fired','player_shot_resolved']){
     if(!result.summary.eventTypes.includes(eventName)){
       fail(`Galaxy Guardians runtime did not emit ${eventName}`, result);
@@ -120,6 +146,7 @@ async function main(){
     visualIds: result.summary.visualIds,
     audioCueIds: result.summary.audioCueIds,
     eventTypes: result.summary.eventTypes,
+    timing: result.timing,
     score: result.summary.score
   }, null, 2));
 }

--- a/tools/harness/check-game-picker-shell.js
+++ b/tools/harness/check-game-picker-shell.js
@@ -46,17 +46,14 @@ async function main(){
       const marquee = document.getElementById('cabinetMarqueeTitle')?.textContent || '';
       const msg = document.getElementById('msg')?.innerText || '';
       const modalOpen = document.getElementById('gamePreviewModal')?.classList.contains('open');
-      const previewTitle = document.getElementById('gamePreviewTitle')?.textContent || '';
-      const banner = document.getElementById('gamePreviewBanner')?.textContent || '';
-      const summary = document.getElementById('gamePreviewSummary')?.textContent || '';
-      const milestones = document.getElementById('gamePreviewMilestones')?.innerText || '';
-      return title.includes('Galaxy Guardians') && marquee.includes('Galaxy Guardians') && msg.includes('GALAXY GUARDIANS') && modalOpen
-        ? { title, marquee, msg: msg.replace(/\s+/g, ' ').trim(), previewTitle, banner, summary, milestones: milestones.replace(/\s+/g, ' ').trim() }
+      const packKey = typeof window.currentGamePackKey === 'function' ? window.currentGamePackKey() : '';
+      const hasPlayableAdapter = typeof window.currentGamePackHasPlayableAdapter === 'function' ? window.currentGamePackHasPlayableAdapter() : null;
+      const hasDevPreviewAdapter = typeof window.currentGamePackHasDevPreviewAdapter === 'function' ? window.currentGamePackHasDevPreviewAdapter() : null;
+      const canStart = typeof window.currentGamePackCanStart === 'function' ? window.currentGamePackCanStart() : null;
+      return title.includes('Galaxy Guardians') && marquee.includes('Galaxy Guardians') && msg.includes('GALAXY GUARDIANS') && packKey === 'galaxy-guardians-preview'
+        ? { title, marquee, msg: msg.replace(/\s+/g, ' ').trim(), modalOpen, packKey, hasPlayableAdapter, hasDevPreviewAdapter, canStart }
         : null;
     }, 1200, 40);
-
-    await page.locator('#gamePreviewClose').click();
-    await page.waitForTimeout(160);
 
     const beforeTheme = await page.evaluate(() =>
       getComputedStyle(document.documentElement).getPropertyValue('--marquee-border').trim()
@@ -80,18 +77,18 @@ async function main(){
     await page.keyboard.press('Escape');
     await page.waitForTimeout(120);
     await page.keyboard.press('Enter');
-    const blocked = await waitForHarness(page, () => {
+    const launched = await waitForHarness(page, () => {
       const started = !!window.__galagaHarness__.snapshot().started;
       const modalOpen = !!document.getElementById('gamePreviewModal')?.classList.contains('open');
-      const previewTitle = document.getElementById('gamePreviewTitle')?.textContent || '';
       const marquee = document.getElementById('cabinetMarqueeTitle')?.textContent || '';
       const packKey = typeof window.currentGamePackKey === 'function' ? window.currentGamePackKey() : '';
-      return started && packKey === 'aurora-galactica'
-        ? { started, modalOpen, previewTitle, marquee, packKey }
+      const guardians = typeof window.__galagaHarness__.guardiansState === 'function' ? window.__galagaHarness__.guardiansState() : null;
+      return started && packKey === 'galaxy-guardians-preview'
+        ? { started, modalOpen, marquee, packKey, guardians }
         : null;
     }, 1200, 40);
 
-    return { opened, preview, beforeTheme, themed, blocked };
+    return { opened, preview, beforeTheme, themed, launched };
   });
 
   if(!result.opened?.railVisible) fail('left-side game picker rail did not render', result);
@@ -102,18 +99,14 @@ async function main(){
   }
   if(
     !result.preview?.msg.includes('GALAXY GUARDIANS')
-    || !result.preview?.msg.includes('PREVIEW SHELL')
-    || !result.preview?.msg.includes('PRESS ENTER TO RETURN TO AURORA')
+    || result.preview?.hasPlayableAdapter !== false
+    || result.preview?.hasDevPreviewAdapter !== true
+    || result.preview?.canStart !== true
   ){
-    fail('preview pack selection did not update the split app/platform wait-mode copy', result);
+    fail('preview pack selection did not update the split app/platform wait-mode copy and dev-preview boundary', result);
   }
-  if(
-    !result.preview?.previewTitle.includes('Galaxy Guardians')
-    || !result.preview?.banner.includes('SNEAK PEEK')
-    || !result.preview?.summary.includes('pack-owned content')
-    || !result.preview?.milestones.includes('Pack identity and shell preview')
-  ){
-    fail('preview pack selection did not open the pack-owned sneak-peek splash', result);
+  if(result.preview?.modalOpen){
+    fail('dev-preview pack selection opened the sneak-peek splash instead of leaving Enter available for the dev playable preview', result);
   }
   if(result.beforeTheme === result.themed?.border){
     fail('switching shell theme did not change the cabinet chrome treatment', result);
@@ -121,14 +114,14 @@ async function main(){
   if(!result.themed?.themeLine.includes('Classic Blue')){
     fail('shell theme picker did not update the current theme label', result);
   }
-  if(!result.blocked?.started){
-    fail('launching from the preview shell did not fall back to Aurora gameplay', result);
+  if(!result.launched?.started){
+    fail('launching from the preview shell did not start the Guardians dev playable preview', result);
   }
-  if(result.blocked?.modalOpen){
-    fail('preview modal stayed open instead of launching Aurora', result);
+  if(result.launched?.modalOpen){
+    fail('preview modal opened during Guardians dev playable launch', result);
   }
-  if(result.blocked?.packKey !== 'aurora-galactica' || !result.blocked?.marquee.includes('Aurora Galactica')){
-    fail('launch fallback did not restore Aurora as the active playable pack', result);
+  if(result.launched?.packKey !== 'galaxy-guardians-preview' || !result.launched?.marquee.includes('Galaxy Guardians') || result.launched?.guardians?.gameKey !== 'galaxy-guardians-preview'){
+    fail('launch did not stay inside the Galaxy Guardians dev-preview pack', result);
   }
 
   console.log(JSON.stringify({
@@ -137,7 +130,7 @@ async function main(){
     previewTitle: result.preview.title,
     previewMarquee: result.preview.marquee,
     themedBorder: result.themed.border,
-    launchPackKey: result.blocked.packKey
+    launchPackKey: result.launched.packKey
   }, null, 2));
 }
 

--- a/tools/harness/check-gameplay-adapter-boundaries.js
+++ b/tools/harness/check-gameplay-adapter-boundaries.js
@@ -11,13 +11,16 @@ async function main(){
   const result = await withHarnessPage({ skipStart: true, stage: 2, ships: 2, seed: 91827 }, async ({ page }) => {
     const initial = await page.evaluate(() => {
       const adapters = typeof availableGameplayAdapters === 'function' ? availableGameplayAdapters() : {};
+      const devAdapters = typeof availableDevPreviewGameplayAdapters === 'function' ? availableDevPreviewGameplayAdapters() : {};
       const packs = typeof availableGamePacks === 'function' ? availableGamePacks() : {};
       return {
         adapterKeys: Object.keys(adapters),
+        devAdapterKeys: Object.keys(devAdapters),
         auroraPackPlayable: typeof packIsPlayable === 'function' ? packIsPlayable(packs['aurora-galactica']) : null,
         guardiansPackPlayable: typeof packIsPlayable === 'function' ? packIsPlayable(packs['galaxy-guardians-preview']) : null,
         auroraHasAdapter: typeof gamePackHasPlayableAdapter === 'function' ? gamePackHasPlayableAdapter('aurora-galactica') : null,
         guardiansHasAdapter: typeof gamePackHasPlayableAdapter === 'function' ? gamePackHasPlayableAdapter('galaxy-guardians-preview') : null,
+        guardiansHasDevAdapter: typeof gamePackHasDevPreviewAdapter === 'function' ? gamePackHasDevPreviewAdapter('galaxy-guardians-preview') : null,
         currentKey: typeof currentGamePackKey === 'function' ? currentGamePackKey() : '',
         currentHasAdapter: typeof currentGamePackHasPlayableAdapter === 'function' ? currentGamePackHasPlayableAdapter() : null
       };
@@ -31,23 +34,27 @@ async function main(){
       key: currentGamePackKey(),
       playable: currentGamePackPlayable(),
       hasAdapter: currentGamePackHasPlayableAdapter(),
+      hasDevAdapter: currentGamePackHasDevPreviewAdapter(),
+      canStart: currentGamePackCanStart(),
       started: window.__galagaHarness__.state().started
     }));
 
     await page.keyboard.press('Enter');
-    const launchFallback = await waitForHarness(page, () => {
+    const launchDevPreview = await waitForHarness(page, () => {
       const state = window.__galagaHarness__.state();
       if(!state.started) return null;
       return {
         key: currentGamePackKey(),
         hasAdapter: currentGamePackHasPlayableAdapter(),
+        hasDevAdapter: currentGamePackHasDevPreviewAdapter(),
         started: !!state.started,
         stage: state.stage,
-        snapshotGameKey: window.__galagaHarness__.snapshot().gameKey || ''
+        snapshotGameKey: window.__galagaHarness__.snapshot().gameKey || '',
+        guardians: window.__galagaHarness__.guardiansState()
       };
     }, 2600, 40);
 
-    return { initial, previewInstalled, launchFallback };
+    return { initial, previewInstalled, launchDevPreview };
   });
 
   if(!result.initial.adapterKeys.includes('aurora-galactica')){
@@ -56,31 +63,39 @@ async function main(){
   if(result.initial.adapterKeys.includes('galaxy-guardians-preview')){
     fail('Galaxy Guardians registered a gameplay adapter before its owned gameplay slice exists', result);
   }
+  if(!result.initial.devAdapterKeys.includes('galaxy-guardians-preview') || result.initial.devAdapterKeys.includes('aurora-galactica')){
+    fail('Galaxy Guardians dev-only preview adapter registry is not isolated from the public gameplay registry', result);
+  }
   if(result.initial.auroraPackPlayable !== true || result.initial.auroraHasAdapter !== true){
     fail('Aurora is not both metadata-playable and adapter-playable', result);
   }
-  if(result.initial.guardiansPackPlayable !== false || result.initial.guardiansHasAdapter !== false){
-    fail('Galaxy Guardians preview is not blocked by the gameplay adapter boundary', result);
+  if(result.initial.guardiansPackPlayable !== false || result.initial.guardiansHasAdapter !== false || result.initial.guardiansHasDevAdapter !== true){
+    fail('Galaxy Guardians preview is not correctly split between public adapter blocking and dev-only preview routing', result);
   }
-  if(result.previewInstalled.key !== 'galaxy-guardians-preview' || result.previewInstalled.hasAdapter !== false){
-    fail('Galaxy Guardians preview did not enter the expected non-adapter state before launch', result);
+  if(result.previewInstalled.key !== 'galaxy-guardians-preview' || result.previewInstalled.hasAdapter !== false || result.previewInstalled.hasDevAdapter !== true || result.previewInstalled.canStart !== true){
+    fail('Galaxy Guardians preview did not enter the expected dev-preview adapter state before launch', result);
   }
   if(result.previewInstalled.started){
-    fail('Galaxy Guardians preview started gameplay before launch fallback', result);
+    fail('Galaxy Guardians preview started gameplay before explicit launch', result);
   }
-  if(result.launchFallback.key !== 'aurora-galactica' || result.launchFallback.snapshotGameKey !== 'aurora-galactica'){
-    fail('Preview launch did not fall back to the Aurora gameplay adapter', result);
+  if(result.launchDevPreview.key !== 'galaxy-guardians-preview' || result.launchDevPreview.snapshotGameKey !== 'galaxy-guardians-preview'){
+    fail('Galaxy Guardians dev-preview launch did not stay inside the Guardians pack boundary', result);
   }
-  if(result.launchFallback.hasAdapter !== true || !result.launchFallback.started){
-    fail('Fallback did not start through a playable gameplay adapter', result);
+  if(result.launchDevPreview.hasAdapter !== false || result.launchDevPreview.hasDevAdapter !== true || !result.launchDevPreview.started){
+    fail('Galaxy Guardians dev-preview did not start through the dev-only adapter path', result);
+  }
+  if(!result.launchDevPreview.guardians || result.launchDevPreview.guardians.publicPlayable !== 0 || result.launchDevPreview.guardians.devPlayable !== 1){
+    fail('Galaxy Guardians dev-preview launch did not expose the expected runtime summary', result);
   }
 
   console.log(JSON.stringify({
     ok: true,
     adapterKeys: result.initial.adapterKeys,
+    devAdapterKeys: result.initial.devAdapterKeys,
     guardiansHasAdapter: result.initial.guardiansHasAdapter,
-    fallbackPack: result.launchFallback.key,
-    fallbackStage: result.launchFallback.stage
+    guardiansHasDevAdapter: result.initial.guardiansHasDevAdapter,
+    launchedPack: result.launchDevPreview.key,
+    launchedStage: result.launchDevPreview.stage
   }, null, 2));
 }
 

--- a/tools/harness/check-platinum-pack-boot.js
+++ b/tools/harness/check-platinum-pack-boot.js
@@ -78,12 +78,17 @@ async function main(){
         settingsRuntime: document.getElementById('settingsRuntime')?.textContent || '',
         buildStampChannel: document.getElementById('buildStampChannel')?.textContent || '',
         waitText: (document.getElementById('msg')?.innerText || '').replace(/\s+/g, ' ').trim(),
-        previewOpen: !!document.getElementById('gamePreviewModal')?.classList.contains('open')
+        previewOpen: !!document.getElementById('gamePreviewModal')?.classList.contains('open'),
+        hasPlayableAdapter: typeof currentGamePackHasPlayableAdapter === 'function' ? currentGamePackHasPlayableAdapter() : null,
+        hasDevPreviewAdapter: typeof currentGamePackHasDevPreviewAdapter === 'function' ? currentGamePackHasDevPreviewAdapter() : null,
+        canStart: typeof currentGamePackCanStart === 'function' ? currentGamePackCanStart() : null
       };
     }, WAIT_TIMEOUT_MS, 40);
 
-    await page.locator('#gamePreviewClose').click();
-    await page.waitForTimeout(120);
+    if(previewWait.previewOpen){
+      await page.locator('#gamePreviewClose').click();
+      await page.waitForTimeout(120);
+    }
 
     await openPicker(page);
     await choosePack(page, 'aurora-galactica');
@@ -149,7 +154,10 @@ async function main(){
     fail('Preview pack did not update the visible Platinum runtime label', result);
   }
   if(!result.previewWait.waitText.includes('GALAXY GUARDIANS')) fail('Preview pack did not replace the wait-mode front-door copy', result);
-  if(!result.previewWait.previewOpen) fail('Preview pack did not open the coming-soon splash', result);
+  if(result.previewWait.previewOpen) fail('Dev-preview pack opened the coming-soon splash instead of selecting the playable preview path', result);
+  if(result.previewWait.hasPlayableAdapter !== false || result.previewWait.hasDevPreviewAdapter !== true || result.previewWait.canStart !== true){
+    fail('Preview pack did not expose the expected dev-only playable-preview boundary in wait mode', result);
+  }
 
   if(result.restoredWait.packKey !== 'aurora-galactica') fail('Aurora was not restorable through the selected-pack path', result);
   if(!result.restoredWait.settingsRuntime.includes('Platinum · Aurora Galactica')){


### PR DESCRIPTION
## Summary
- add a development-only Galaxy Guardians playable-preview adapter while keeping the public playable adapter registry Aurora-only
- route Guardians keyboard movement/fire into the owned runtime and add life-loss, reset, and game-over flow
- add harness coverage for public/dev adapter isolation, first timing bands, keyboard fire, life loss/reset/game over, and picker/pack boot behavior
- update Platinum application/boundary/architecture docs for the dev-preview cadence

## Verification
- npm run build
- npm run harness:check:galaxy-guardians-runtime-slice
- npm run harness:check:guardians-adapter-skeleton
- npm run harness:check:gameplay-adapter-boundaries
- npm run harness:check:galaxy-guardians-playable-preview
- npm run harness:check:platinum-pack-boot
- node tools/harness/check-game-picker-shell.js
- npm run harness:check:compact-cabinet-rails
- npm run harness:check:platinum-renderer-boundaries
- npm run harness:check:pack-registry-boundaries
- git diff --check