### PR TITLE
Start Guardians visual audio identity baseline

### DIFF
--- a/APPLICATIONS_ON_PLATINUM.md
+++ b/APPLICATIONS_ON_PLATINUM.md
@@ -258,6 +258,12 @@ Current development-only playable-preview coverage:
   shot, life-loss, reset, and game-over mechanics
 - `src/js/13-gameplay-adapter-registry.js` keeps public playable adapters and
   dev-preview adapters in separate registries
+- `reference-artifacts/analyses/galaxy-guardians-identity/identity-baseline-0.1.json`
+  persists the first 0.1 visual/audio identity contract so future sprite,
+  movement, and cue edits have a durable artifact trail
+- `tools/harness/check-galaxy-guardians-identity-baseline.js` proves the
+  identity artifact matches the pack-owned sprite rows, audio cue catalog, audio
+  theme cues, runtime cue map, and dev-preview audio history
 - `tools/harness/check-galaxy-guardians-playable-preview.js` proves keyboard
   fire, life loss, reset, game over, owned audio cue IDs, and public-adapter
   isolation

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -190,6 +190,11 @@ Pack-boundary harness:
   flagship/escort/scout roles, single-shot firing, promoted event emission,
   Guardians-owned scoring, Guardians-owned visual/audio catalog bindings, and
   no Aurora capture/challenge/dual-fighter state.
+- `tools/harness/check-galaxy-guardians-identity-baseline.js`
+  verifies that the persistent 0.1 identity artifact in
+  `reference-artifacts/analyses/galaxy-guardians-identity/` matches the
+  pack-owned sprite glyphs, audio cue catalog, theme cues, runtime cue map, and
+  dev-preview audio history.
 - `tools/harness/check-galaxy-guardians-playable-preview.js`
   verifies the development-only Galaxy Guardians playable-preview adapter:
   keyboard fire routing, life loss, reset, game over, owned audio cue IDs, and

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "harness:check:stage1-late-parity": "node tools/harness/check-stage1-late-clear-parity.js",
     "harness:check:stage2-carryover": "node tools/harness/check-stage2-carryover-parity.js",
     "harness:check:galaxian-reference-profile": "node tools/harness/check-galaxian-reference-profile.js",
+    "harness:check:galaxy-guardians-identity-baseline": "node tools/harness/check-galaxy-guardians-identity-baseline.js",
     "harness:check:galaxy-guardians-runtime-slice": "node tools/harness/check-galaxy-guardians-runtime-slice.js",
     "harness:check:galaxy-guardians-playable-preview": "node tools/harness/check-galaxy-guardians-playable-preview.js",
     "harness:check:gameplay-adapter-boundaries": "node tools/harness/check-gameplay-adapter-boundaries.js",

--- a/reference-artifacts/analyses/galaxy-guardians-identity/README.md
+++ b/reference-artifacts/analyses/galaxy-guardians-identity/README.md
@@ -1,0 +1,15 @@
+# Galaxy Guardians Identity Baseline
+
+This folder stores persistent artifacts for the first `Galaxy Guardians` 0.1
+visual and audio identity pass.
+
+The artifacts here are intentionally source-controlled because the second-game
+preview is now part of the Platinum release planning path. Runtime tuning,
+visual glyph edits, and audio cue edits should cite durable files here rather
+than living only in chat or in transient harness output.
+
+Current artifacts:
+
+- `identity-baseline-0.1.json` - first application-owned sprite, palette, audio,
+  and timing contract for the development-only playable preview.
+

--- a/reference-artifacts/analyses/galaxy-guardians-identity/identity-baseline-0.1.json
+++ b/reference-artifacts/analyses/galaxy-guardians-identity/identity-baseline-0.1.json
@@ -1,0 +1,120 @@
+{
+  "gameKey": "galaxy-guardians-preview",
+  "artifactType": "visual-audio-identity-baseline",
+  "version": "0.1-dev-preview",
+  "createdOn": "2026-05-02",
+  "status": "dev-preview-baseline-not-public-release-art",
+  "sourceEvidence": {
+    "referenceProfile": "reference-artifacts/analyses/galaxian-reference/initial-measured-profile.json",
+    "promotedEventLog": "reference-artifacts/analyses/galaxian-reference/promoted-event-log.json",
+    "notes": "First baseline derives from the measured Galaxian reference profile and is deliberately stored as a reviewable contract before deeper frame-accurate sprite and audio extraction."
+  },
+  "visualLanguage": {
+    "pixelAlphabet": {
+      ".": "transparent",
+      "C": "core",
+      "W": "wing",
+      "A": "accent",
+      "E": "eye",
+      "F": "flare",
+      "X": "legacy-filled-pixel"
+    },
+    "paletteIntent": "signal-red, command-gold, cyan, green, and cold-white; intentionally not Aurora bee/butterfly/boss/capture naming",
+    "sprites": [
+      {
+        "id": "signal-flagship",
+        "role": "flagship",
+        "silhouette": "wide command crown with red outriggers and gold core",
+        "rows": [
+          ".....A.....",
+          "...AWEWA...",
+          "..WWCCCWW..",
+          ".WCCECECCW.",
+          "WWCCCCCCCWW",
+          "W.CCAACC.W",
+          "...W...W..."
+        ]
+      },
+      {
+        "id": "signal-escort",
+        "role": "escort",
+        "silhouette": "red arrow escort with blue wing tips",
+        "rows": [
+          "...A...",
+          "..WCW..",
+          ".WCCCW.",
+          "WWCEWW",
+          ".ACCA.",
+          "W..W..W"
+        ]
+      },
+      {
+        "id": "signal-scout",
+        "role": "scout",
+        "silhouette": "green-cyan wing scout",
+        "rows": [
+          "...A...",
+          ".WACAW.",
+          "WWCCCWW",
+          "..ECE..",
+          ".WCCAW.",
+          "W.....W"
+        ]
+      },
+      {
+        "id": "player-interceptor",
+        "role": "player",
+        "silhouette": "single-shot interceptor with yellow nose and red engine flare",
+        "rows": [
+          "...A...",
+          "..CCC..",
+          ".WCECW.",
+          "WWCCCWW",
+          "..WAW..",
+          "...F..."
+        ]
+      }
+    ]
+  },
+  "audioLanguage": {
+    "themeId": "guardians-signal",
+    "intent": "short, dry square-wave cue language with separate dive, escort, wrap, hit, loss, and game-over cues",
+    "requiredCueNames": [
+      "gameStart",
+      "formationPulse",
+      "playerShot",
+      "enemyShot",
+      "scoutDive",
+      "flagshipDive",
+      "escortJoin",
+      "scoutHit",
+      "escortHit",
+      "flagshipHit",
+      "wrapReturn",
+      "playerLoss",
+      "gameOver"
+    ],
+    "runtimeCueMap": {
+      "player_shot_fired": "playerShot",
+      "alien_dive_start": "scoutDive",
+      "flagship_dive_start": "flagshipDive",
+      "escort_join": "escortJoin",
+      "enemy_wrap_or_return": "wrapReturn",
+      "player_lost": "playerLoss",
+      "game_over": "gameOver"
+    }
+  },
+  "timingBaseline": {
+    "firstScoutDiveDelaySeconds": 2.2,
+    "flagshipEscortDelaySeconds": 6.4,
+    "singleShotCooldownSeconds": 0.72,
+    "playerRespawnDelaySeconds": 1.35,
+    "playerInvulnerabilitySeconds": 0.95
+  },
+  "harness": {
+    "identityCheck": "tools/harness/check-galaxy-guardians-identity-baseline.js",
+    "runtimeCheck": "tools/harness/check-galaxy-guardians-runtime-slice.js",
+    "playablePreviewCheck": "tools/harness/check-galaxy-guardians-playable-preview.js"
+  }
+}
+

--- a/src/js/13-galaxy-guardians-game-pack.js
+++ b/src/js/13-galaxy-guardians-game-pack.js
@@ -47,15 +47,15 @@ const GUARDIANS_ALIEN_VISUAL_CATALOG=Object.freeze({
   label:'Signal Flagship',
   role:'flagship',
   silhouette:'crowned-command-ship',
-  palette:Object.freeze({core:'#ffdf6f',wing:'#ff5b5b',accent:'#7bd6ff',eye:'#fff7c2'}),
+  palette:Object.freeze({core:'#ffdf6f',wing:'#ff5b5b',accent:'#7bd6ff',eye:'#fff7c2',flare:'#ff9f43'}),
   pixelRows:Object.freeze([
-   '....X....',
-   '...XXX...',
-   '..XXXXX..',
-   '.XX.X.XX.',
-   'XXXXXXXXX',
-   'X.XXXXX.X',
-   '..X...X..'
+   '.....A.....',
+   '...AWEWA...',
+   '..WWCCCWW..',
+   '.WCCECECCW.',
+   'WWCCCCCCCWW',
+   'W.CCAACC.W',
+   '...W...W...'
   ]),
   notes:'Wide crowned command silhouette for flagship-with-escort dives; intentionally not an Aurora boss/capture ship.'
  }),
@@ -64,14 +64,14 @@ const GUARDIANS_ALIEN_VISUAL_CATALOG=Object.freeze({
   label:'Signal Escort',
   role:'escort',
   silhouette:'red-arrow-escort',
-  palette:Object.freeze({core:'#ff5b5b',wing:'#35b9ff',accent:'#ffe06d',eye:'#ffffff'}),
+  palette:Object.freeze({core:'#ff5b5b',wing:'#35b9ff',accent:'#ffe06d',eye:'#ffffff',flare:'#ff9f43'}),
   pixelRows:Object.freeze([
-   '..X.X..',
-   '.XXXXX.',
-   'XXX.XXX',
-   '.XXXXX.',
-   'X.X.X.X',
-   '..X.X..'
+   '...A...',
+   '..WCW..',
+   '.WCCCW.',
+   'WWCEWW',
+   '.ACCA.',
+   'W..W..W'
   ]),
   notes:'Small red escort marker for paired flagship pressure rather than Aurora butterfly behavior.'
  }),
@@ -80,14 +80,14 @@ const GUARDIANS_ALIEN_VISUAL_CATALOG=Object.freeze({
   label:'Signal Scout',
   role:'scout',
   silhouette:'cyan-wing-scout',
-  palette:Object.freeze({core:'#42f285',wing:'#4b7dff',accent:'#ffdf6f',eye:'#f8fbff'}),
+  palette:Object.freeze({core:'#42f285',wing:'#4b7dff',accent:'#ffdf6f',eye:'#f8fbff',flare:'#ff5b5b'}),
   pixelRows:Object.freeze([
-   '...X...',
-   '.X.X.X.',
-   'XXXXXXX',
-   '..XXX..',
-   '.X.X.X.',
-   'X.....X'
+   '...A...',
+   '.WACAW.',
+   'WWCCCWW',
+   '..ECE..',
+   '.WCCAW.',
+   'W.....W'
   ]),
   notes:'Cyan-green rank-and-file scout for sparse Galaxian-like solo dives.'
  }),
@@ -96,13 +96,14 @@ const GUARDIANS_ALIEN_VISUAL_CATALOG=Object.freeze({
   label:'Guardian Interceptor',
   role:'player',
   silhouette:'single-shot-interceptor',
-  palette:Object.freeze({core:'#dff7ff',wing:'#7bd6ff',accent:'#ffdf6f',flare:'#ff5b5b'}),
+  palette:Object.freeze({core:'#dff7ff',wing:'#7bd6ff',accent:'#ffdf6f',eye:'#ffffff',flare:'#ff5b5b'}),
   pixelRows:Object.freeze([
-   '...X...',
-   '..XXX..',
-   '.XXXXX.',
-   'XXX.XXX',
-   '..X.X..'
+   '...A...',
+   '..CCC..',
+   '.WCECW.',
+   'WWCCCWW',
+   '..WAW..',
+   '...F...'
   ]),
   notes:'Single-fighter player craft sized for one-shot precision; no Aurora dual-fighter silhouette.'
  })
@@ -120,7 +121,8 @@ const GUARDIANS_AUDIO_CUE_CATALOG=Object.freeze({
  escortHit:Object.freeze({id:'guardians-escort-hit',event:'player_shot_resolved',profile:'red-blue-snap',referenceIntent:'escort hit'}),
  flagshipHit:Object.freeze({id:'guardians-flagship-hit',event:'player_shot_resolved',profile:'gold-command-break',referenceIntent:'flagship hit / score moment'}),
  wrapReturn:Object.freeze({id:'guardians-wrap-return',event:'enemy_wrap_or_return',profile:'soft-bottom-return-sweep',referenceIntent:'bottom-exit or return warning'}),
- playerLoss:Object.freeze({id:'guardians-player-loss',event:'player_lost',profile:'falling-square-burst',referenceIntent:'future life-loss cue'})
+ playerLoss:Object.freeze({id:'guardians-player-loss',event:'player_lost',profile:'falling-square-burst',referenceIntent:'life-loss cue for the dev playable preview'}),
+ gameOver:Object.freeze({id:'guardians-game-over-fall',event:'game_over',profile:'low-falling-square-stair',referenceIntent:'short game-over descent distinct from Aurora'})
 });
 
 const GUARDIANS_AUDIO_THEMES=Object.freeze({
@@ -128,9 +130,18 @@ const GUARDIANS_AUDIO_THEMES=Object.freeze({
   id:'guardians-signal',
   label:'Guardians Signal',
   cues:Object.freeze({
-   gameStart:Object.freeze({seq:[330,392,523,659],step:.05,wave:'square',volume:.015,slide:18,lpHz:3400}),
-   playerShot:Object.freeze({tones:Object.freeze([{freq:1180,duration:.032,wave:'square',volume:.007,slide:-700,lpHz:6200}])}),
+   gameStart:Object.freeze({seq:[294,370,494,659],step:.052,wave:'square',volume:.014,slide:22,lpHz:3300}),
+   formationPulse:Object.freeze({tones:Object.freeze([{freq:196,duration:.08,wave:'square',volume:.0035,slide:4,lpHz:1700},{freq:392,duration:.058,wave:'square',volume:.008,slide:-10,lpHz:3000,delay:.012}])}),
+   playerShot:Object.freeze({tones:Object.freeze([{freq:1240,duration:.03,wave:'square',volume:.0075,slide:-820,lpHz:6400},{freq:1680,duration:.018,wave:'square',volume:.0032,slide:-520,lpHz:7200,delay:.006}])}),
    enemyShot:Object.freeze({tones:Object.freeze([{freq:286,duration:.085,wave:'square',volume:.009,slide:-140,lpHz:2700}])}),
+   scoutDive:Object.freeze({tones:Object.freeze([{freq:392,duration:.09,wave:'square',volume:.006,slide:-120,lpHz:2600},{freq:294,duration:.12,wave:'square',volume:.005,slide:-90,lpHz:2300,delay:.055}])}),
+   flagshipDive:Object.freeze({tones:Object.freeze([{freq:262,duration:.16,wave:'square',volume:.0075,slide:-80,lpHz:2400},{freq:196,duration:.22,wave:'triangle',volume:.006,slide:-70,lpHz:1900,delay:.06}])}),
+   escortJoin:Object.freeze({seq:[660,587,660],step:.032,wave:'square',volume:.006,slide:-24,lpHz:4300}),
+   wrapReturn:Object.freeze({tones:Object.freeze([{freq:220,duration:.16,wave:'triangle',volume:.0055,slide:120,lpHz:2200}])}),
+   playerLoss:Object.freeze({tones:Object.freeze([{freq:240,duration:.12,wave:'square',volume:.017,slide:-190,lpHz:2200},{freq:170,duration:.18,wave:'sawtooth',volume:.014,slide:-120,lpHz:1700,delay:.04}]),noise:Object.freeze([{duration:.09,volume:.007,hp:950,delay:.015}])}),
+   scoutHit:Object.freeze({tones:Object.freeze([{freq:282,duration:.045,wave:'square',volume:.011,slide:-230,lpHz:3600}])}),
+   escortHit:Object.freeze({tones:Object.freeze([{freq:340,duration:.052,wave:'square',volume:.012,slide:-210,lpHz:3800},{freq:220,duration:.05,wave:'triangle',volume:.005,slide:-120,lpHz:2600,delay:.012}])}),
+   flagshipHit:Object.freeze({tones:Object.freeze([{freq:420,duration:.07,wave:'square',volume:.013,slide:-150,lpHz:3900},{freq:260,duration:.08,wave:'triangle',volume:.006,slide:-110,lpHz:2600,delay:.018}])}),
    enemyHit:Object.freeze({tones:Object.freeze([{freq:246,duration:.055,wave:'square',volume:.012,slide:-210,lpHz:3300}])}),
    bossHit:Object.freeze({tones:Object.freeze([{freq:320,duration:.068,wave:'square',volume:.013,slide:-120,lpHz:3600}])}),
    enemyBoom:Object.freeze({tones:Object.freeze([{freq:420,duration:.04,wave:'square',volume:.009,slide:-320,lpHz:3900},{freq:220,duration:.08,wave:'triangle',volume:.006,slide:-110,lpHz:2100,delay:.014}])}),

--- a/src/js/13-galaxy-guardians-gameplay-adapter.js
+++ b/src/js/13-galaxy-guardians-gameplay-adapter.js
@@ -204,6 +204,7 @@ function startGalaxyGuardiansDevPreview(cfg={}){
   ships:Math.max(1,+cfg.ships||+testCfg.ships||3),
   seed:(+cfg.seed>>>0)||(+localStorage.getItem(SEED_PREF_KEY)>>>0)||42719
  });
+ GALAXY_GUARDIANS_ACTIVE_DEV_STATE.audioEventIndex=GALAXY_GUARDIANS_ACTIVE_DEV_STATE.events.length;
  syncGalaxyGuardiansShellState(GALAXY_GUARDIANS_ACTIVE_DEV_STATE);
  if(typeof resetHarnessFrameClock==='function')resetHarnessFrameClock();
  if(typeof syncPauseUi==='function')syncPauseUi();
@@ -226,6 +227,7 @@ function galaxyGuardiansInputFromKeys(){
 function updateGalaxyGuardiansDevPreview(dt){
  if(!GALAXY_GUARDIANS_ACTIVE_DEV_STATE)return;
  stepGalaxyGuardiansRuntime(GALAXY_GUARDIANS_ACTIVE_DEV_STATE,dt,galaxyGuardiansInputFromKeys());
+ playGalaxyGuardiansRuntimeCues(GALAXY_GUARDIANS_ACTIVE_DEV_STATE);
  syncGalaxyGuardiansShellState(GALAXY_GUARDIANS_ACTIVE_DEV_STATE);
  if(GALAXY_GUARDIANS_ACTIVE_DEV_STATE.gameOver){
   started=0;
@@ -233,6 +235,35 @@ function updateGalaxyGuardiansDevPreview(dt){
   if(typeof syncPauseUi==='function')syncPauseUi();
   stopRunRecording();
  }
+}
+
+function galaxyGuardiansCueNameForRuntimeEvent(event){
+ if(!event)return '';
+ if(event.type==='player_shot_fired')return 'playerShot';
+ if(event.type==='alien_dive_start')return 'scoutDive';
+ if(event.type==='flagship_dive_start')return 'flagshipDive';
+ if(event.type==='escort_join')return 'escortJoin';
+ if(event.type==='enemy_wrap_or_return')return 'wrapReturn';
+ if(event.type==='player_lost')return 'playerLoss';
+ if(event.type==='game_over')return 'gameOver';
+ if(event.type==='player_shot_resolved'){
+  if(event.result!=='hit')return '';
+  if(event.role==='flagship')return 'flagshipHit';
+  if(event.role==='escort')return 'escortHit';
+  return 'scoutHit';
+ }
+ return '';
+}
+
+function playGalaxyGuardiansRuntimeCues(state){
+ if(!state||!Array.isArray(state.events)||typeof sfx==='undefined'||typeof sfx.playCue!=='function')return;
+ const start=Math.max(0,+state.audioEventIndex||0);
+ for(let i=start;i<state.events.length;i++){
+  const cueName=galaxyGuardiansCueNameForRuntimeEvent(state.events[i]);
+  if(!cueName)continue;
+  sfx.playCue(cueName,{phase:'stage',gameKey:GALAXY_GUARDIANS_PACK.metadata.gameKey});
+ }
+ state.audioEventIndex=state.events.length;
 }
 
 function currentGalaxyGuardiansDevPreviewState(){

--- a/src/js/13-galaxy-guardians-runtime.js
+++ b/src/js/13-galaxy-guardians-runtime.js
@@ -238,7 +238,7 @@ function loseGalaxyGuardiansPlayer(state,cause='collision'){
  });
  if(state.lives<=0){
   state.gameOver=1;
-  guardiansRuntimeEvent(state,'game_over',{score:state.score,stage:state.stage});
+  guardiansRuntimeEvent(state,'game_over',{score:state.score,stage:state.stage,audioCue:GALAXY_GUARDIANS_PACK.audioCueCatalog.gameOver.id});
  }
  return true;
 }

--- a/src/js/22-galaxy-guardians-preview-renderer.js
+++ b/src/js/22-galaxy-guardians-preview-renderer.js
@@ -43,14 +43,24 @@ function drawGalaxyGuardiansPixelRows(visual,x,y,cell=2,opts={}){
  const wing=opts.wing||palette.wing||core;
  const accent=opts.accent||palette.accent||core;
  const eye=opts.eye||palette.eye||'#ffffff';
+ const flare=opts.flare||palette.flare||accent;
+ const colorForPixel=(ch,edge,center)=>{
+  if(ch==='C')return core;
+  if(ch==='W')return wing;
+  if(ch==='A')return accent;
+  if(ch==='E')return eye;
+  if(ch==='F')return flare;
+  return edge?wing:(center?accent:core);
+ };
  ctx.save();
  ctx.translate(Math.round(x-width*cell/2),Math.round(y-height*cell/2));
  for(let row=0;row<rows.length;row++){
   for(let col=0;col<rows[row].length;col++){
-   if(rows[row][col]!== 'X')continue;
+   const pixel=rows[row][col];
+   if(pixel==='.')continue;
    const edge=col===0||col===rows[row].length-1||row===0||row===rows.length-1;
    const center=Math.abs(col-(rows[row].length-1)/2)<1.1;
-   ctx.fillStyle=edge?wing:(center?accent:core);
+   ctx.fillStyle=colorForPixel(pixel,edge,center);
    ctx.fillRect(col*cell,row*cell,cell,cell);
   }
  }

--- a/tools/harness/check-galaxy-guardians-identity-baseline.js
+++ b/tools/harness/check-galaxy-guardians-identity-baseline.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const ARTIFACT = path.join(ROOT, 'reference-artifacts', 'analyses', 'galaxy-guardians-identity', 'identity-baseline-0.1.json');
+const PACK_SOURCE = path.join(ROOT, 'src', 'js', '13-galaxy-guardians-game-pack.js');
+const ADAPTER_SOURCE = path.join(ROOT, 'src', 'js', '13-galaxy-guardians-gameplay-adapter.js');
+
+function fail(message, payload){
+  console.error(message);
+  if(payload) console.error(JSON.stringify(payload, null, 2));
+  process.exit(1);
+}
+
+function loadGuardiansPack(){
+  const source = fs.readFileSync(PACK_SOURCE, 'utf8');
+  const sandbox = {};
+  vm.createContext(sandbox);
+  vm.runInContext(`${source}\nthis.GALAXY_GUARDIANS_PACK=GALAXY_GUARDIANS_PACK;`, sandbox, { filename: PACK_SOURCE });
+  return sandbox.GALAXY_GUARDIANS_PACK;
+}
+
+function main(){
+  const artifact = JSON.parse(fs.readFileSync(ARTIFACT, 'utf8'));
+  const pack = loadGuardiansPack();
+  const adapterSource = fs.readFileSync(ADAPTER_SOURCE, 'utf8');
+  const visualCatalog = pack.alienVisualCatalog || {};
+  const cueCatalog = pack.audioCueCatalog || {};
+  const theme = pack.audioThemes?.['guardians-signal'] || {};
+  const themeCues = theme.cues || {};
+  const allowedPixels = new Set(Object.keys(artifact.visualLanguage.pixelAlphabet || {}));
+  const payload = {
+    artifactStatus: artifact.status,
+    packKey: pack.metadata?.gameKey || '',
+    visualCatalogKeys: Object.keys(visualCatalog),
+    cueCatalogKeys: Object.keys(cueCatalog),
+    themeCueKeys: Object.keys(themeCues),
+    artifactSprites: artifact.visualLanguage?.sprites || [],
+    artifactRequiredCues: artifact.audioLanguage?.requiredCueNames || [],
+    runtimeCueMap: artifact.audioLanguage?.runtimeCueMap || {}
+  };
+
+  if(payload.packKey !== artifact.gameKey || payload.artifactStatus !== 'dev-preview-baseline-not-public-release-art'){
+    fail('Galaxy Guardians identity artifact is not linked to the preview pack', payload);
+  }
+  for(const sprite of payload.artifactSprites){
+    const runtime = visualCatalog[sprite.id];
+    if(!runtime){
+      fail(`Identity artifact sprite ${sprite.id} is missing from the pack visual catalog`, payload);
+    }
+    const runtimeRows = Array.from(runtime.pixelRows || []);
+    if(JSON.stringify(runtimeRows) !== JSON.stringify(sprite.rows)){
+      fail(`Identity artifact sprite ${sprite.id} no longer matches the pack visual rows`, { sprite, runtimeRows });
+    }
+    for(const row of runtimeRows){
+      for(const pixel of row){
+        if(!allowedPixels.has(pixel)){
+          fail(`Identity sprite ${sprite.id} uses unregistered pixel token ${pixel}`, { sprite, row });
+        }
+      }
+    }
+    for(const forbidden of ['bee','butterfly','boss','capture','dual']){
+      if(`${sprite.id} ${sprite.role} ${sprite.silhouette}`.toLowerCase().includes(forbidden)){
+        fail(`Identity artifact sprite leaks Aurora-oriented naming: ${forbidden}`, sprite);
+      }
+    }
+  }
+  for(const cueName of payload.artifactRequiredCues){
+    if(!payload.cueCatalogKeys.includes(cueName)){
+      fail(`Identity artifact cue ${cueName} is missing from the pack audio cue catalog`, payload);
+    }
+    if(!payload.themeCueKeys.includes(cueName)){
+      fail(`Identity artifact cue ${cueName} is missing from the Guardians signal audio theme`, payload);
+    }
+  }
+  for(const [eventName, cueName] of Object.entries(payload.runtimeCueMap)){
+    if(!adapterSource.includes(`event.type==='${eventName}'`) || !adapterSource.includes(`return '${cueName}'`)){
+      fail(`Runtime cue map ${eventName} -> ${cueName} is not wired in the Guardians dev adapter`, payload);
+    }
+  }
+  if(!adapterSource.includes('playGalaxyGuardiansRuntimeCues(GALAXY_GUARDIANS_ACTIVE_DEV_STATE)')){
+    fail('Guardians dev adapter does not play mapped runtime cues after stepping the runtime', payload);
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    artifact: path.relative(ROOT, ARTIFACT),
+    sprites: payload.artifactSprites.map(sprite => sprite.id),
+    cueCatalogKeys: payload.cueCatalogKeys,
+    themeCueKeys: payload.themeCueKeys.filter(key => payload.artifactRequiredCues.includes(key))
+  }, null, 2));
+}
+
+main();
+


### PR DESCRIPTION
## Summary
- add a persistent Galaxy Guardians 0.1 visual/audio identity artifact under reference-artifacts
- upgrade the first Guardians sprite glyph rows and renderer pixel alphabet for pack-owned visual identity
- add Guardians-specific audio cue catalog/theme coverage for dive, escort, wrap, hit, loss, and game-over cues
- wire runtime events to dev-preview audio cue playback
- add a Node-only identity baseline harness so the artifact contract does not depend on Chrome startup health

## Verification
- npm run build
- npm run harness:check:galaxy-guardians-identity-baseline
- npm run harness:check:galaxy-guardians-runtime-slice
- npm run harness:check:galaxy-guardians-playable-preview
- npm run harness:check:platinum-renderer-boundaries
- npm run harness:check:compact-cabinet-rails
- git diff --check