### PR TITLE
Add Guardians movement pacing baseline

### DIFF
--- a/APPLICATIONS_ON_PLATINUM.md
+++ b/APPLICATIONS_ON_PLATINUM.md
@@ -261,9 +261,15 @@ Current development-only playable-preview coverage:
 - `reference-artifacts/analyses/galaxy-guardians-identity/identity-baseline-0.1.json`
   persists the first 0.1 visual/audio identity contract so future sprite,
   movement, and cue edits have a durable artifact trail
+- `reference-artifacts/analyses/galaxy-guardians-identity/movement-pacing-0.1.json`
+  persists the first movement and pressure pacing contract for solo dives,
+  flagship/escort attacks, and bottom wrap/return cycles
 - `tools/harness/check-galaxy-guardians-identity-baseline.js` proves the
   identity artifact matches the pack-owned sprite rows, audio cue catalog, audio
   theme cues, runtime cue map, and dev-preview audio history
+- `tools/harness/check-galaxy-guardians-movement-pacing.js` proves the runtime
+  rules match the persistent movement artifact and that flagship dives attach
+  real escort craft in sampled runtime state
 - `tools/harness/check-galaxy-guardians-playable-preview.js` proves keyboard
   fire, life loss, reset, game over, owned audio cue IDs, and public-adapter
   isolation

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -195,6 +195,10 @@ Pack-boundary harness:
   `reference-artifacts/analyses/galaxy-guardians-identity/` matches the
   pack-owned sprite glyphs, audio cue catalog, theme cues, runtime cue map, and
   dev-preview audio history.
+- `tools/harness/check-galaxy-guardians-movement-pacing.js`
+  verifies that the persistent movement/pacing artifact matches runtime rules
+  and that sampled scout/flagship/escort dive behavior exposes real linked
+  escort craft and wrap/return pressure.
 - `tools/harness/check-galaxy-guardians-playable-preview.js`
   verifies the development-only Galaxy Guardians playable-preview adapter:
   keyboard fire routing, life loss, reset, game over, owned audio cue IDs, and

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "harness:check:stage2-carryover": "node tools/harness/check-stage2-carryover-parity.js",
     "harness:check:galaxian-reference-profile": "node tools/harness/check-galaxian-reference-profile.js",
     "harness:check:galaxy-guardians-identity-baseline": "node tools/harness/check-galaxy-guardians-identity-baseline.js",
+    "harness:check:galaxy-guardians-movement-pacing": "node tools/harness/check-galaxy-guardians-movement-pacing.js",
     "harness:check:galaxy-guardians-runtime-slice": "node tools/harness/check-galaxy-guardians-runtime-slice.js",
     "harness:check:galaxy-guardians-playable-preview": "node tools/harness/check-galaxy-guardians-playable-preview.js",
     "harness:check:gameplay-adapter-boundaries": "node tools/harness/check-gameplay-adapter-boundaries.js",

--- a/reference-artifacts/analyses/galaxy-guardians-identity/README.md
+++ b/reference-artifacts/analyses/galaxy-guardians-identity/README.md
@@ -12,4 +12,5 @@ Current artifacts:
 
 - `identity-baseline-0.1.json` - first application-owned sprite, palette, audio,
   and timing contract for the development-only playable preview.
-
+- `movement-pacing-0.1.json` - first runtime movement and pressure pacing
+  contract for solo dives, flagship/escort dives, and wrap/return pressure.

--- a/reference-artifacts/analyses/galaxy-guardians-identity/movement-pacing-0.1.json
+++ b/reference-artifacts/analyses/galaxy-guardians-identity/movement-pacing-0.1.json
@@ -1,0 +1,61 @@
+{
+  "gameKey": "galaxy-guardians-preview",
+  "artifactType": "movement-pacing-baseline",
+  "version": "0.1-dev-preview",
+  "createdOn": "2026-05-02",
+  "status": "dev-preview-pacing-contract-not-public-release-tuning",
+  "sourceEvidence": {
+    "referenceProfile": "reference-artifacts/analyses/galaxian-reference/initial-measured-profile.json",
+    "promotedEventLog": "reference-artifacts/analyses/galaxian-reference/promoted-event-log.json",
+    "movementWindows": [
+      {
+        "event": "alien_dive_start",
+        "sourceId": "arcades-lounge-level-5",
+        "observedWindowSeconds": [20, 30],
+        "intent": "solo lower-field pressure from independent rack exits"
+      },
+      {
+        "event": "flagship_dive_start",
+        "sourceId": "nenriki-15-wave-session",
+        "observedWindowSeconds": [90, 135],
+        "intent": "top-rank flagship pressure with escorts"
+      },
+      {
+        "event": "enemy_wrap_or_return",
+        "sourceId": "nenriki-15-wave-session",
+        "observedWindowSeconds": [105, 150],
+        "intent": "bottom-exit/return pressure cycles"
+      }
+    ]
+  },
+  "runtimeRules": {
+    "playerSpeedPxPerSecond": 118,
+    "formationDriftAmplitudePx": 2.7,
+    "formationDriftHz": 2.05,
+    "scoutDiveIntervalBaseSeconds": 1.72,
+    "scoutDiveIntervalJitterSeconds": 0.95,
+    "flagshipDiveIntervalBaseSeconds": 6.6,
+    "flagshipDiveIntervalJitterSeconds": 1.65,
+    "diveSwayAmplitudePx": 29,
+    "diveSwayHz": 4.45,
+    "diveSideDriftPxPerSecond": 13,
+    "diveBaseVyPxPerSecond": 74,
+    "diveAccelPxPerSecondSquared": 16,
+    "escortSpacingPx": 14,
+    "escortLagSeconds": 0.1,
+    "escortYOffsetPx": 7,
+    "bottomExitPaddingPx": 12
+  },
+  "runtimeExpectations": {
+    "firstScoutDiveBandSeconds": [2.18, 2.28],
+    "firstFlagshipDiveBandSeconds": [6.38, 6.48],
+    "escortJoinDeltaSeconds": [0, 0.001],
+    "minimumLinkedEscortCountOnFirstFlagshipDive": 2,
+    "minimumWrapEventsByNineSeconds": 1
+  },
+  "harness": {
+    "movementPacingCheck": "tools/harness/check-galaxy-guardians-movement-pacing.js",
+    "runtimeCheck": "tools/harness/check-galaxy-guardians-runtime-slice.js"
+  }
+}
+

--- a/src/js/13-galaxy-guardians-runtime.js
+++ b/src/js/13-galaxy-guardians-runtime.js
@@ -68,6 +68,22 @@ const GALAXY_GUARDIANS_RUNTIME_PROFILE=Object.freeze({
   singleShotCooldown:.72,
   firstScoutDiveDelay:2.2,
   flagshipEscortDelay:6.4,
+  playerSpeed:118,
+  formationDriftAmplitude:2.7,
+  formationDriftHz:2.05,
+  scoutDiveIntervalBase:1.72,
+  scoutDiveIntervalJitter:.95,
+  flagshipDiveIntervalBase:6.6,
+  flagshipDiveIntervalJitter:1.65,
+  diveSwayAmplitude:29,
+  diveSwayHz:4.45,
+  diveSideDrift:13,
+  diveBaseVy:74,
+  diveAccel:16,
+  escortSpacing:14,
+  escortLag:.1,
+  escortYOffset:7,
+  bottomExitPadding:12,
   playerRespawnDelay:1.35,
   playerInvulnerability:.95,
   wrapThreatModel:'bottom-exit-or-return-explicit-preview-rule',
@@ -112,7 +128,9 @@ function createGalaxyGuardiansFormation(){
    mode:'formation',
    diveT:0,
    diveSide:col<5?-1:1,
-   escorts:0
+   escorts:0,
+   escortSlot:0,
+   linkedTo:''
   });
  };
  for(let col=4;col<=5;col++)push('flagship',0,col,44+col*21,52);
@@ -180,22 +198,49 @@ function pickGuardiansAlien(state,role=''){
  return candidates[index];
 }
 
+function pickGuardiansEscortAliens(state,count=0,leader=null){
+ const escorts=liveGuardiansAliens(state,'escort')
+  .filter(alien=>alien.mode==='formation')
+  .sort((a,b)=>Math.abs(a.x-(leader?.x||a.x))-Math.abs(b.x-(leader?.x||b.x)));
+ return escorts.slice(0,Math.max(0,count|0));
+}
+
 function startGuardiansDive(state,alien,escortCount=0){
  if(!alien||alien.hp<=0)return null;
+ const rules=GALAXY_GUARDIANS_RUNTIME_PROFILE.rules;
  alien.mode='diving';
  alien.diveT=0;
  alien.diveStartX=alien.x;
  alien.diveStartY=alien.y;
  alien.diveSide=alien.x<GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.playfieldWidth/2?-1:1;
  alien.escorts=escortCount;
+ alien.linkedTo='';
+ alien.escortSlot=0;
+ const escorts=alien.role==='flagship'?pickGuardiansEscortAliens(state,escortCount,alien):[];
+ alien.escorts=escorts.length;
  guardiansRuntimeEvent(state,alien.role==='flagship'?'flagship_dive_start':'alien_dive_start',{
   id:alien.id,
   role:alien.role,
   visualId:alien.visualId,
   audioCue:GALAXY_GUARDIANS_RUNTIME_ALIEN_CATALOG[alien.type]?.diveAudioCue||'',
-  escorts:escortCount
+  escorts:escorts.length
  });
- if(escortCount>0)guardiansRuntimeEvent(state,'escort_join',{flagship:alien.id,escorts:escortCount,audioCue:GALAXY_GUARDIANS_PACK.audioCueCatalog.escortJoin.id});
+ escorts.forEach((escort,index)=>{
+  escort.mode='diving';
+  escort.diveT=-rules.escortLag*(index+1);
+  escort.diveStartX=escort.x;
+  escort.diveStartY=escort.y;
+  escort.diveSide=alien.diveSide;
+  escort.linkedTo=alien.id;
+  escort.escortSlot=index===0?-1:1;
+  escort.escorts=0;
+ });
+ if(escorts.length>0)guardiansRuntimeEvent(state,'escort_join',{
+  flagship:alien.id,
+  escorts:escorts.length,
+  escortIds:escorts.map(escort=>escort.id),
+  audioCue:GALAXY_GUARDIANS_PACK.audioCueCatalog.escortJoin.id
+ });
  return alien;
 }
 
@@ -268,35 +313,44 @@ function stepGalaxyGuardiansRuntime(state,dt=.016,input={}){
   if(!state.resetT)resetGalaxyGuardiansWave(state,'life_reset');
   return state;
  }
- p.x=Math.max(12,Math.min(rules.playfieldWidth-12,p.x+move*112*dt));
+ p.x=Math.max(12,Math.min(rules.playfieldWidth-12,p.x+move*rules.playerSpeed*dt));
  if(input.fire)fireGuardiansPlayerShot(state);
  if(state.t>=state.nextDiveAt){
   const alien=pickGuardiansAlien(state,'scout')||pickGuardiansAlien(state);
   startGuardiansDive(state,alien,0);
-  state.nextDiveAt=state.t+1.85+state.rng()*1.1;
+  state.nextDiveAt=state.t+rules.scoutDiveIntervalBase+state.rng()*rules.scoutDiveIntervalJitter;
  }
  if(state.t>=state.nextFlagshipAt){
   const flagship=pickGuardiansAlien(state,'flagship');
   startGuardiansDive(state,flagship,Math.min(2,liveGuardiansAliens(state,'escort').length));
-  state.nextFlagshipAt=state.t+7.2+state.rng()*2.2;
+  state.nextFlagshipAt=state.t+rules.flagshipDiveIntervalBase+state.rng()*rules.flagshipDiveIntervalJitter;
  }
  for(const alien of state.aliens){
   if(alien.hp<=0)continue;
   if(alien.mode==='formation'){
-   const drift=Math.sin(state.t*2.2+alien.row*.7)*2.4;
+   const drift=Math.sin(state.t*rules.formationDriftHz+alien.row*.7)*rules.formationDriftAmplitude;
    alien.x=alien.rackX+drift;
    alien.y=alien.rackY;
    continue;
   }
   alien.diveT+=dt;
-  const q=alien.diveT;
-  alien.x=alien.diveStartX+Math.sin(q*4.2)*24*alien.diveSide+alien.diveSide*q*10;
-  alien.y=alien.diveStartY+q*68+q*q*13;
-  if(alien.y>rules.playfieldHeight+12){
+  const leader=alien.linkedTo?state.aliens.find(candidate=>candidate.id===alien.linkedTo&&candidate.hp>0):null;
+  if(leader&&leader.mode==='diving'){
+   const slot=alien.escortSlot||1;
+   alien.x=leader.x+slot*rules.escortSpacing;
+   alien.y=leader.y+rules.escortYOffset+Math.max(0,alien.diveT)*4;
+  }else{
+   const q=Math.max(0,alien.diveT);
+   alien.x=alien.diveStartX+Math.sin(q*rules.diveSwayHz)*rules.diveSwayAmplitude*alien.diveSide+alien.diveSide*q*rules.diveSideDrift;
+   alien.y=alien.diveStartY+q*rules.diveBaseVy+q*q*rules.diveAccel;
+  }
+  if(alien.y>rules.playfieldHeight+rules.bottomExitPadding){
    alien.mode='formation';
    alien.diveT=0;
    alien.x=alien.rackX;
    alien.y=alien.rackY;
+   alien.linkedTo='';
+   alien.escortSlot=0;
    guardiansRuntimeEvent(state,'enemy_wrap_or_return',{id:alien.id,role:alien.role,visualId:alien.visualId,audioCue:GALAXY_GUARDIANS_PACK.audioCueCatalog.wrapReturn.id});
   }
   if(alien.mode==='diving'&&p.visible&&p.inv<=0&&Math.abs(alien.x-p.x)<=10&&Math.abs(alien.y-p.y)<=10){
@@ -347,6 +401,7 @@ function summarizeGalaxyGuardiansRuntime(state){
   playerInv:+(+state.player.inv||0).toFixed(3),
   resetT:+(+state.resetT||0).toFixed(3),
   gameOver:!!state.gameOver,
+  activeDives:state.aliens.filter(alien=>alien.hp>0&&alien.mode==='diving').map(alien=>({id:alien.id,role:alien.role,linkedTo:alien.linkedTo||'',escortSlot:alien.escortSlot||0,x:+alien.x.toFixed(2),y:+alien.y.toFixed(2)})),
   eventTypes:Array.from(new Set(state.events.map(event=>event.type))),
   visualIds:Array.from(new Set(state.aliens.filter(alien=>alien.hp>0).map(alien=>alien.visualId))),
   audioCueIds:Array.from(new Set(state.events.map(event=>event.audioCue).filter(Boolean))),

--- a/tools/harness/check-galaxy-guardians-movement-pacing.js
+++ b/tools/harness/check-galaxy-guardians-movement-pacing.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const ARTIFACT = path.join(ROOT, 'reference-artifacts', 'analyses', 'galaxy-guardians-identity', 'movement-pacing-0.1.json');
+const PACK_SOURCE = path.join(ROOT, 'src', 'js', '13-galaxy-guardians-game-pack.js');
+const RUNTIME_SOURCE = path.join(ROOT, 'src', 'js', '13-galaxy-guardians-runtime.js');
+
+function fail(message, payload){
+  console.error(message);
+  if(payload) console.error(JSON.stringify(payload, null, 2));
+  process.exit(1);
+}
+
+function loadGuardiansRuntime(){
+  const packSource = fs.readFileSync(PACK_SOURCE, 'utf8');
+  const runtimeSource = fs.readFileSync(RUNTIME_SOURCE, 'utf8');
+  const sandbox = {
+    window: null,
+    GALAXY_GUARDIANS_ADAPTER_FORBIDDEN_AURORA_CAPABILITIES: Object.freeze({
+      usesCaptureRescue: 0,
+      usesDualFighterMode: 0,
+      usesChallengeStages: 0,
+      usesAuroraScoring: 0,
+      usesAuroraEnemyFamilies: 0
+    })
+  };
+  sandbox.window = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(`${packSource}\n${runtimeSource}`, sandbox, { filename: 'galaxy-guardians-runtime-vm.js' });
+  return sandbox;
+}
+
+function main(){
+  const artifact = JSON.parse(fs.readFileSync(ARTIFACT, 'utf8'));
+  const runtime = loadGuardiansRuntime();
+  const state = runtime.createGalaxyGuardiansRuntimeState({ stage: 1, ships: 3, seed: 42719 });
+  state.player.inv = 999;
+  const samples = [];
+  for(let i=0;i<620;i++){
+    runtime.stepGalaxyGuardiansRuntime(state, 1/60, { fire: i % 90 === 0 });
+    if(i % 30 === 0){
+      const summary = runtime.summarizeGalaxyGuardiansRuntime(state);
+      samples.push({
+        t: +state.t.toFixed(3),
+        activeDives: summary.activeDives,
+        events: summary.eventTypes
+      });
+    }
+  }
+  const summary = runtime.summarizeGalaxyGuardiansRuntime(state);
+  const firstScoutDive = state.events.find(event => event.type === 'alien_dive_start');
+  const firstFlagshipDive = state.events.find(event => event.type === 'flagship_dive_start');
+  const firstEscortJoin = state.events.find(event => event.type === 'escort_join');
+  const wrapCount = state.events.filter(event => event.type === 'enemy_wrap_or_return').length;
+  const linkedEscortSamples = samples.flatMap(sample => sample.activeDives.filter(dive => dive.linkedTo));
+  const rules = runtime.GALAXY_GUARDIANS_RUNTIME_PROFILE.rules;
+  const result = {
+    specStatus: artifact.status,
+    rules: {
+      playerSpeedPxPerSecond: rules.playerSpeed,
+      formationDriftAmplitudePx: rules.formationDriftAmplitude,
+      formationDriftHz: rules.formationDriftHz,
+      scoutDiveIntervalBaseSeconds: rules.scoutDiveIntervalBase,
+      scoutDiveIntervalJitterSeconds: rules.scoutDiveIntervalJitter,
+      flagshipDiveIntervalBaseSeconds: rules.flagshipDiveIntervalBase,
+      flagshipDiveIntervalJitterSeconds: rules.flagshipDiveIntervalJitter,
+      diveSwayAmplitudePx: rules.diveSwayAmplitude,
+      diveSwayHz: rules.diveSwayHz,
+      diveSideDriftPxPerSecond: rules.diveSideDrift,
+      diveBaseVyPxPerSecond: rules.diveBaseVy,
+      diveAccelPxPerSecondSquared: rules.diveAccel,
+      escortSpacingPx: rules.escortSpacing,
+      escortLagSeconds: rules.escortLag,
+      escortYOffsetPx: rules.escortYOffset,
+      bottomExitPaddingPx: rules.bottomExitPadding
+    },
+    firstScoutDive,
+    firstFlagshipDive,
+    firstEscortJoin,
+    wrapCount,
+    linkedEscortSamples,
+    summary
+  };
+
+  if(result.specStatus !== 'dev-preview-pacing-contract-not-public-release-tuning'){
+    fail('Guardians movement/pacing artifact has the wrong status', result);
+  }
+  for(const [key, expected] of Object.entries(artifact.runtimeRules || {})){
+    if(Math.abs((+result.rules[key] || 0) - (+expected || 0)) > .0001){
+      fail(`Runtime pacing rule ${key} drifted from the persistent artifact`, result);
+    }
+  }
+  const bands = artifact.runtimeExpectations || {};
+  const inBand = (value, band) => Number.isFinite(+value) && Array.isArray(band) && +value >= band[0] && +value <= band[1];
+  if(!inBand(result.firstScoutDive?.t, bands.firstScoutDiveBandSeconds)){
+    fail('First scout dive timing drifted outside the movement/pacing artifact band', result);
+  }
+  if(!inBand(result.firstFlagshipDive?.t, bands.firstFlagshipDiveBandSeconds)){
+    fail('First flagship dive timing drifted outside the movement/pacing artifact band', result);
+  }
+  const escortDelta = +(result.firstEscortJoin?.t - result.firstFlagshipDive?.t).toFixed(3);
+  if(!inBand(escortDelta, bands.escortJoinDeltaSeconds)){
+    fail('Escort join timing no longer matches the flagship dive event window', result);
+  }
+  if((result.firstEscortJoin?.escorts || 0) < bands.minimumLinkedEscortCountOnFirstFlagshipDive){
+    fail('First flagship dive did not attach the expected escort count', result);
+  }
+  if(result.linkedEscortSamples.length < bands.minimumLinkedEscortCountOnFirstFlagshipDive){
+    fail('Movement samples did not show escorts linked to a flagship dive', result);
+  }
+  if(result.wrapCount < bands.minimumWrapEventsByNineSeconds){
+    fail('Runtime did not produce enough wrap/return pressure by the pacing window', result);
+  }
+  if(!result.summary.activeDives || !Array.isArray(result.summary.activeDives)){
+    fail('Runtime summary no longer exposes active dive snapshots for movement review', result);
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    artifact: path.relative(ROOT, ARTIFACT),
+    firstScoutDiveT: result.firstScoutDive.t,
+    firstFlagshipDiveT: result.firstFlagshipDive.t,
+    escortJoinT: result.firstEscortJoin.t,
+    escortIds: result.firstEscortJoin.escortIds,
+    wrapCount: result.wrapCount,
+    linkedEscortSamples: result.linkedEscortSamples.length
+  }, null, 2));
+}
+
+try {
+  main();
+} catch (err) {
+  fail(err && err.stack || String(err));
+}


### PR DESCRIPTION
## Summary
- add a persistent Galaxy Guardians movement/pacing artifact for the first 0.1 preview contract
- move Guardians runtime movement values into explicit rules and add linked flagship escort dives
- add a Node-side harness that verifies runtime pacing against the artifact without needing browser launch stability
- document the new artifact and harness in the Platinum application and architecture docs

## Verification
- npm run build
- npm run harness:check:galaxy-guardians-movement-pacing
- npm run harness:check:galaxy-guardians-identity-baseline
- npm run harness:check:galaxy-guardians-runtime-slice
- npm run harness:check:galaxy-guardians-playable-preview
- npm run harness:check:platinum-renderer-boundaries
- npm run harness:check:compact-cabinet-rails
- git diff --check

## Release authority
No beta or production publish action was run from this MacBook.