### PR TITLE
Add Guardians threat scoring baseline

### DIFF
--- a/APPLICATIONS_ON_PLATINUM.md
+++ b/APPLICATIONS_ON_PLATINUM.md
@@ -264,12 +264,18 @@ Current development-only playable-preview coverage:
 - `reference-artifacts/analyses/galaxy-guardians-identity/movement-pacing-0.1.json`
   persists the first movement and pressure pacing contract for solo dives,
   flagship/escort attacks, and bottom wrap/return cycles
+- `reference-artifacts/analyses/galaxy-guardians-identity/threat-scoring-0.1.json`
+  persists the first lower-field threat and application-owned scoring contract
+  for enemy shots, player loss, and formation/dive hit values
 - `tools/harness/check-galaxy-guardians-identity-baseline.js` proves the
   identity artifact matches the pack-owned sprite rows, audio cue catalog, audio
   theme cues, runtime cue map, and dev-preview audio history
 - `tools/harness/check-galaxy-guardians-movement-pacing.js` proves the runtime
   rules match the persistent movement artifact and that flagship dives attach
   real escort craft in sampled runtime state
+- `tools/harness/check-galaxy-guardians-threat-scoring.js` proves the runtime
+  rules match the persistent threat/scoring artifact and that enemy-shot
+  pressure, player loss, and owned point values are active
 - `tools/harness/check-galaxy-guardians-playable-preview.js` proves keyboard
   fire, life loss, reset, game over, owned audio cue IDs, and public-adapter
   isolation

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -199,6 +199,10 @@ Pack-boundary harness:
   verifies that the persistent movement/pacing artifact matches runtime rules
   and that sampled scout/flagship/escort dive behavior exposes real linked
   escort craft and wrap/return pressure.
+- `tools/harness/check-galaxy-guardians-threat-scoring.js`
+  verifies that the persistent lower-field threat/scoring artifact matches
+  runtime rules and that enemy shots, player loss, and owned point values stay
+  in the Galaxy Guardians application layer.
 - `tools/harness/check-galaxy-guardians-playable-preview.js`
   verifies the development-only Galaxy Guardians playable-preview adapter:
   keyboard fire routing, life loss, reset, game over, owned audio cue IDs, and

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "harness:check:galaxian-reference-profile": "node tools/harness/check-galaxian-reference-profile.js",
     "harness:check:galaxy-guardians-identity-baseline": "node tools/harness/check-galaxy-guardians-identity-baseline.js",
     "harness:check:galaxy-guardians-movement-pacing": "node tools/harness/check-galaxy-guardians-movement-pacing.js",
+    "harness:check:galaxy-guardians-threat-scoring": "node tools/harness/check-galaxy-guardians-threat-scoring.js",
     "harness:check:galaxy-guardians-runtime-slice": "node tools/harness/check-galaxy-guardians-runtime-slice.js",
     "harness:check:galaxy-guardians-playable-preview": "node tools/harness/check-galaxy-guardians-playable-preview.js",
     "harness:check:gameplay-adapter-boundaries": "node tools/harness/check-gameplay-adapter-boundaries.js",

--- a/reference-artifacts/analyses/galaxy-guardians-identity/README.md
+++ b/reference-artifacts/analyses/galaxy-guardians-identity/README.md
@@ -14,3 +14,5 @@ Current artifacts:
   and timing contract for the development-only playable preview.
 - `movement-pacing-0.1.json` - first runtime movement and pressure pacing
   contract for solo dives, flagship/escort dives, and wrap/return pressure.
+- `threat-scoring-0.1.json` - first lower-field threat and application-owned
+  scoring contract for enemy shots, player loss, and hit values.

--- a/reference-artifacts/analyses/galaxy-guardians-identity/identity-baseline-0.1.json
+++ b/reference-artifacts/analyses/galaxy-guardians-identity/identity-baseline-0.1.json
@@ -96,6 +96,7 @@
     ],
     "runtimeCueMap": {
       "player_shot_fired": "playerShot",
+      "enemy_shot": "enemyShot",
       "alien_dive_start": "scoutDive",
       "flagship_dive_start": "flagshipDive",
       "escort_join": "escortJoin",
@@ -117,4 +118,3 @@
     "playablePreviewCheck": "tools/harness/check-galaxy-guardians-playable-preview.js"
   }
 }
-

--- a/reference-artifacts/analyses/galaxy-guardians-identity/threat-scoring-0.1.json
+++ b/reference-artifacts/analyses/galaxy-guardians-identity/threat-scoring-0.1.json
@@ -1,0 +1,62 @@
+{
+  "gameKey": "galaxy-guardians-preview",
+  "artifactType": "threat-scoring-baseline",
+  "version": "0.1-dev-preview",
+  "createdOn": "2026-05-02",
+  "status": "dev-preview-threat-scoring-contract-not-public-release-tuning",
+  "sourceEvidence": {
+    "referenceProfile": "reference-artifacts/analyses/galaxian-reference/initial-measured-profile.json",
+    "promotedEventLog": "reference-artifacts/analyses/galaxian-reference/promoted-event-log.json",
+    "threatWindows": [
+      {
+        "event": "enemy_shot",
+        "sourceId": "arcades-lounge-level-5",
+        "observedWindowSeconds": [20, 30],
+        "intent": "thin lower-field shot pressure while solo dives begin"
+      },
+      {
+        "event": "player_lost",
+        "sourceId": "nenriki-15-wave-session",
+        "observedWindowSeconds": [105, 150],
+        "intent": "bottom pressure can convert into player loss without Aurora capture or dual-fighter state"
+      },
+      {
+        "event": "player_shot_resolved",
+        "sourceId": "nenriki-15-wave-session",
+        "observedWindowSeconds": [90, 135],
+        "intent": "application-owned scoring for formation, dive, and escorted flagship hits"
+      }
+    ]
+  },
+  "runtimeRules": {
+    "firstEnemyShotDelaySeconds": 3.1,
+    "enemyShotIntervalBaseSeconds": 1.15,
+    "enemyShotIntervalJitterSeconds": 0.75,
+    "enemyShotVyPxPerSecond": 94,
+    "enemyShotMaxLive": 3,
+    "enemyShotStartYOffsetPx": 8,
+    "enemyShotPlayerHitboxPx": 7,
+    "enemyShotBottomPaddingPx": 10
+  },
+  "scoringRules": {
+    "scoutFormationPoints": 30,
+    "scoutDivePoints": 60,
+    "escortFormationPoints": 50,
+    "escortDivePoints": 100,
+    "flagshipFormationPoints": 150,
+    "flagshipDivePoints": 300,
+    "flagshipOneEscortDivePoints": 500,
+    "flagshipTwoEscortDivePoints": 800
+  },
+  "runtimeExpectations": {
+    "firstEnemyShotBandSeconds": [3.08, 3.13],
+    "minimumEnemyShotsBySixSeconds": 2,
+    "maximumLiveEnemyShots": 3,
+    "requiredAudioCueId": "guardians-enemy-shot",
+    "requiredPlayerLossCause": "enemy_shot"
+  },
+  "harness": {
+    "threatScoringCheck": "tools/harness/check-galaxy-guardians-threat-scoring.js",
+    "runtimeCheck": "tools/harness/check-galaxy-guardians-runtime-slice.js"
+  }
+}

--- a/src/js/13-galaxy-guardians-gameplay-adapter.js
+++ b/src/js/13-galaxy-guardians-gameplay-adapter.js
@@ -57,6 +57,7 @@ const GALAXY_GUARDIANS_REFERENCE_PROFILE=Object.freeze({
   'escort_join',
   'player_shot_fired',
   'player_shot_resolved',
+  'enemy_shot',
   'enemy_wrap_or_return',
   'player_lost',
   'game_over',
@@ -240,6 +241,7 @@ function updateGalaxyGuardiansDevPreview(dt){
 function galaxyGuardiansCueNameForRuntimeEvent(event){
  if(!event)return '';
  if(event.type==='player_shot_fired')return 'playerShot';
+ if(event.type==='enemy_shot')return 'enemyShot';
  if(event.type==='alien_dive_start')return 'scoutDive';
  if(event.type==='flagship_dive_start')return 'flagshipDive';
  if(event.type==='escort_join')return 'escortJoin';

--- a/src/js/13-galaxy-guardians-runtime.js
+++ b/src/js/13-galaxy-guardians-runtime.js
@@ -56,6 +56,7 @@ const GALAXY_GUARDIANS_RUNTIME_PROFILE=Object.freeze({
   'escort_join',
   'player_shot_fired',
   'player_shot_resolved',
+  'enemy_shot',
   'enemy_wrap_or_return',
   'player_lost',
   'game_over',
@@ -84,6 +85,14 @@ const GALAXY_GUARDIANS_RUNTIME_PROFILE=Object.freeze({
   escortLag:.1,
   escortYOffset:7,
   bottomExitPadding:12,
+  firstEnemyShotDelay:3.1,
+  enemyShotIntervalBase:1.15,
+  enemyShotIntervalJitter:.75,
+  enemyShotVy:94,
+  enemyShotMaxLive:3,
+  enemyShotStartYOffset:8,
+  enemyShotPlayerHitbox:7,
+  enemyShotBottomPadding:10,
   playerRespawnDelay:1.35,
   playerInvulnerability:.95,
   wrapThreatModel:'bottom-exit-or-return-explicit-preview-rule',
@@ -160,6 +169,7 @@ function createGalaxyGuardiansRuntimeState(opts={}){
   diveIndex:0,
   nextDiveAt:GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.firstScoutDiveDelay,
   nextFlagshipAt:GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.flagshipEscortDelay,
+  nextEnemyShotAt:GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.firstEnemyShotDelay,
   player:{
    x:GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.playfieldWidth/2,
    y:GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.playfieldHeight-28,
@@ -266,6 +276,7 @@ function resetGalaxyGuardiansWave(state,reason='wave_reset'){
  state.diveIndex=0;
  state.nextDiveAt=state.t+GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.firstScoutDiveDelay;
  state.nextFlagshipAt=state.t+GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.flagshipEscortDelay;
+ state.nextEnemyShotAt=state.t+GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.firstEnemyShotDelay;
  guardiansRuntimeEvent(state,'wave_reset',{reason,aliens:state.aliens.length});
 }
 
@@ -298,6 +309,44 @@ function guardiansAlienPoints(alien){
  return alien.mode==='diving'?spec.divePoints:spec.formationPoints;
 }
 
+function pickGuardiansEnemyShotSource(state){
+ const live=liveGuardiansAliens(state).filter(alien=>alien.y<state.player.y-24);
+ if(!live.length)return null;
+ const active=live.filter(alien=>alien.mode==='diving');
+ const candidates=active.length?active:live.sort((a,b)=>b.y-a.y);
+ const index=Math.floor(state.rng()*candidates.length)%candidates.length;
+ return candidates[index];
+}
+
+function fireGuardiansEnemyShot(state){
+ const rules=GALAXY_GUARDIANS_RUNTIME_PROFILE.rules;
+ const liveShots=state.enemyShots.filter(shot=>shot&&shot.active!==0);
+ if(liveShots.length>=rules.enemyShotMaxLive)return false;
+ const alien=pickGuardiansEnemyShotSource(state);
+ if(!alien)return false;
+ const shot={
+  id:`gg-enemy-shot-${state.events.length}`,
+  sourceId:alien.id,
+  role:alien.role,
+  visualId:alien.visualId,
+  x:alien.x,
+  y:alien.y+rules.enemyShotStartYOffset,
+  vy:rules.enemyShotVy,
+  active:1
+ };
+ state.enemyShots.push(shot);
+ guardiansRuntimeEvent(state,'enemy_shot',{
+  id:shot.id,
+  sourceId:shot.sourceId,
+  role:shot.role,
+  x:+shot.x.toFixed(2),
+  y:+shot.y.toFixed(2),
+  audioCue:GALAXY_GUARDIANS_PACK.audioCueCatalog.enemyShot.id,
+  visualId:shot.visualId
+ });
+ return true;
+}
+
 function stepGalaxyGuardiansRuntime(state,dt=.016,input={}){
  if(!state||state.gameKey!==GALAXY_GUARDIANS_PACK.metadata.gameKey)throw new Error('Invalid Galaxy Guardians runtime state.');
  const rules=GALAXY_GUARDIANS_RUNTIME_PROFILE.rules;
@@ -324,6 +373,10 @@ function stepGalaxyGuardiansRuntime(state,dt=.016,input={}){
   const flagship=pickGuardiansAlien(state,'flagship');
   startGuardiansDive(state,flagship,Math.min(2,liveGuardiansAliens(state,'escort').length));
   state.nextFlagshipAt=state.t+rules.flagshipDiveIntervalBase+state.rng()*rules.flagshipDiveIntervalJitter;
+ }
+ if(state.t>=state.nextEnemyShotAt){
+  fireGuardiansEnemyShot(state);
+  state.nextEnemyShotAt=state.t+rules.enemyShotIntervalBase+state.rng()*rules.enemyShotIntervalJitter;
  }
  for(const alien of state.aliens){
   if(alien.hp<=0)continue;
@@ -356,6 +409,21 @@ function stepGalaxyGuardiansRuntime(state,dt=.016,input={}){
   if(alien.mode==='diving'&&p.visible&&p.inv<=0&&Math.abs(alien.x-p.x)<=10&&Math.abs(alien.y-p.y)<=10){
    loseGalaxyGuardiansPlayer(state,`alien_${alien.role}_collision`);
   }
+ }
+ if(state.enemyShots.length){
+  const activeShots=[];
+  for(const shot of state.enemyShots){
+   if(!shot||shot.active===0)continue;
+   shot.y+=shot.vy*dt;
+   if(shot.y>rules.playfieldHeight+rules.enemyShotBottomPadding)continue;
+   if(p.visible&&p.inv<=0&&Math.abs(shot.x-p.x)<=rules.enemyShotPlayerHitbox&&Math.abs(shot.y-p.y)<=rules.enemyShotPlayerHitbox){
+    shot.active=0;
+    loseGalaxyGuardiansPlayer(state,'enemy_shot');
+    continue;
+   }
+   activeShots.push(shot);
+  }
+  state.enemyShots=activeShots;
  }
  if(p.shot){
   p.shot.y+=p.shot.vy*dt;
@@ -397,6 +465,8 @@ function summarizeGalaxyGuardiansRuntime(state){
   alienCount:state.aliens.filter(alien=>alien.hp>0).length,
   liveRoles:counts,
   hasPlayerShot:!!state.player.shot,
+  enemyShotCount:state.enemyShots.filter(shot=>shot&&shot.active!==0).length,
+  enemyShots:state.enemyShots.filter(shot=>shot&&shot.active!==0).map(shot=>({id:shot.id,role:shot.role,x:+shot.x.toFixed(2),y:+shot.y.toFixed(2)})),
   playerVisible:!!state.player.visible,
   playerInv:+(+state.player.inv||0).toFixed(3),
   resetT:+(+state.resetT||0).toFixed(3),

--- a/src/js/22-galaxy-guardians-preview-renderer.js
+++ b/src/js/22-galaxy-guardians-preview-renderer.js
@@ -110,6 +110,24 @@ function drawGalaxyGuardiansPlayer(player){
  }
 }
 
+function drawGalaxyGuardiansEnemyShots(state){
+ ctx.save();
+ ctx.lineWidth=1.2;
+ ctx.strokeStyle='#ffdf6f';
+ ctx.shadowColor='#ff5b5b';
+ ctx.shadowBlur=7;
+ for(const shot of state.enemyShots||[]){
+  if(!shot||shot.active===0)continue;
+  ctx.beginPath();
+  ctx.moveTo(shot.x,shot.y-4);
+  ctx.lineTo(shot.x,shot.y+5);
+  ctx.stroke();
+  ctx.fillStyle='#fff7c2';
+  ctx.fillRect(shot.x-1,shot.y+4,2,2);
+ }
+ ctx.restore();
+}
+
 function drawGalaxyGuardiansAlien(alien,t){
  const visual=galaxyGuardiansPreviewVisual(alien.visualId);
  if(!visual)return;
@@ -188,6 +206,7 @@ function drawGalaxyGuardiansPreviewBoard({ox,oy,scale,dx,dy}){
  const starfield=typeof syncStarfieldProfile==='function'?syncStarfieldProfile({frontDoor:1,attractPhase:'guardians-preview'}):null;
  drawGalaxyGuardiansPreviewBackdrop(t);
  for(const alien of state.aliens)if(alien.hp>0)drawGalaxyGuardiansAlien(alien,t);
+ drawGalaxyGuardiansEnemyShots(state);
  if(state.player.visible!==false)drawGalaxyGuardiansPlayer(state.player);
  drawGalaxyGuardiansPreviewHud(summary);
  ctx.restore();
@@ -201,6 +220,7 @@ function drawGalaxyGuardiansPreviewBoard({ox,oy,scale,dx,dy}){
   visualIds:summary.visualIds,
   audioCueIds:summary.audioCueIds,
   alienCount:summary.alienCount,
+  enemyShotCount:summary.enemyShotCount,
   score:summary.score
  });
 }

--- a/tools/harness/check-galaxy-guardians-threat-scoring.js
+++ b/tools/harness/check-galaxy-guardians-threat-scoring.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const ARTIFACT = path.join(ROOT, 'reference-artifacts', 'analyses', 'galaxy-guardians-identity', 'threat-scoring-0.1.json');
+const PACK_SOURCE = path.join(ROOT, 'src', 'js', '13-galaxy-guardians-game-pack.js');
+const RUNTIME_SOURCE = path.join(ROOT, 'src', 'js', '13-galaxy-guardians-runtime.js');
+const ADAPTER_SOURCE = path.join(ROOT, 'src', 'js', '13-galaxy-guardians-gameplay-adapter.js');
+
+function fail(message, payload){
+  console.error(message);
+  if(payload) console.error(JSON.stringify(payload, null, 2));
+  process.exit(1);
+}
+
+function loadGuardiansRuntime(){
+  const packSource = fs.readFileSync(PACK_SOURCE, 'utf8');
+  const runtimeSource = fs.readFileSync(RUNTIME_SOURCE, 'utf8');
+  const sandbox = {
+    window: null,
+    GALAXY_GUARDIANS_ADAPTER_FORBIDDEN_AURORA_CAPABILITIES: Object.freeze({
+      usesCaptureRescue: 0,
+      usesDualFighterMode: 0,
+      usesChallengeStages: 0,
+      usesAuroraScoring: 0,
+      usesAuroraEnemyFamilies: 0
+    })
+  };
+  sandbox.window = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(`${packSource}\n${runtimeSource}`, sandbox, { filename: 'galaxy-guardians-threat-scoring-vm.js' });
+  return sandbox;
+}
+
+function hitScore(runtime, type, mode, escorts=0){
+  const state = runtime.createGalaxyGuardiansRuntimeState({ stage: 1, ships: 3, seed: 9001 });
+  state.player.inv = 999;
+  const alien = state.aliens.find(entry => entry.type === type);
+  if(!alien) throw new Error(`Missing alien type ${type}`);
+  alien.mode = mode;
+  alien.escorts = escorts;
+  alien.diveStartX = alien.x;
+  alien.diveStartY = alien.y;
+  alien.diveSide = alien.x < runtime.GALAXY_GUARDIANS_RUNTIME_PROFILE.rules.playfieldWidth / 2 ? -1 : 1;
+  alien.diveT = 0;
+  state.player.shot = { x: alien.x, y: alien.y + 4, vy: -10, active: 1 };
+  runtime.stepGalaxyGuardiansRuntime(state, 0, {});
+  const event = state.events.find(entry => entry.type === 'player_shot_resolved' && entry.result === 'hit');
+  return { score: state.score, event };
+}
+
+function main(){
+  const artifact = JSON.parse(fs.readFileSync(ARTIFACT, 'utf8'));
+  const runtime = loadGuardiansRuntime();
+  const adapterSource = fs.readFileSync(ADAPTER_SOURCE, 'utf8');
+  const rules = runtime.GALAXY_GUARDIANS_RUNTIME_PROFILE.rules;
+  const result = {
+    artifactStatus: artifact.status,
+    rules: {
+      firstEnemyShotDelaySeconds: rules.firstEnemyShotDelay,
+      enemyShotIntervalBaseSeconds: rules.enemyShotIntervalBase,
+      enemyShotIntervalJitterSeconds: rules.enemyShotIntervalJitter,
+      enemyShotVyPxPerSecond: rules.enemyShotVy,
+      enemyShotMaxLive: rules.enemyShotMaxLive,
+      enemyShotStartYOffsetPx: rules.enemyShotStartYOffset,
+      enemyShotPlayerHitboxPx: rules.enemyShotPlayerHitbox,
+      enemyShotBottomPaddingPx: rules.enemyShotBottomPadding
+    },
+    events: {},
+    scoreCases: {
+      scoutFormationPoints: hitScore(runtime, 'scout', 'formation').score,
+      scoutDivePoints: hitScore(runtime, 'scout', 'diving').score,
+      escortFormationPoints: hitScore(runtime, 'escort', 'formation').score,
+      escortDivePoints: hitScore(runtime, 'escort', 'diving').score,
+      flagshipFormationPoints: hitScore(runtime, 'flagship', 'formation').score,
+      flagshipDivePoints: hitScore(runtime, 'flagship', 'diving').score,
+      flagshipOneEscortDivePoints: hitScore(runtime, 'flagship', 'diving', 1).score,
+      flagshipTwoEscortDivePoints: hitScore(runtime, 'flagship', 'diving', 2).score
+    }
+  };
+
+  const threatState = runtime.createGalaxyGuardiansRuntimeState({ stage: 1, ships: 3, seed: 42719 });
+  threatState.player.inv = 999;
+  for(let i=0;i<360;i++) runtime.stepGalaxyGuardiansRuntime(threatState, 1/60, {});
+  const threatSummary = runtime.summarizeGalaxyGuardiansRuntime(threatState);
+  const enemyShotEvents = threatState.events.filter(event => event.type === 'enemy_shot');
+  result.events.firstEnemyShot = enemyShotEvents[0];
+  result.events.enemyShotCount = enemyShotEvents.length;
+  result.events.liveEnemyShotCount = threatSummary.enemyShotCount;
+  result.events.audioCueIds = threatSummary.audioCueIds;
+
+  const lossState = runtime.createGalaxyGuardiansRuntimeState({ stage: 1, ships: 3, seed: 1979 });
+  lossState.player.inv = 0;
+  lossState.enemyShots.push({
+    id: 'forced-threat-harness-shot',
+    role: 'scout',
+    x: lossState.player.x,
+    y: lossState.player.y - 2,
+    vy: 0,
+    active: 1
+  });
+  runtime.stepGalaxyGuardiansRuntime(lossState, 1/60, {});
+  result.events.loss = lossState.events.find(event => event.type === 'player_lost') || null;
+
+  if(result.artifactStatus !== 'dev-preview-threat-scoring-contract-not-public-release-tuning'){
+    fail('Guardians threat/scoring artifact has the wrong status', result);
+  }
+  for(const [key, expected] of Object.entries(artifact.runtimeRules || {})){
+    if(Math.abs((+result.rules[key] || 0) - (+expected || 0)) > .0001){
+      fail(`Runtime threat rule ${key} drifted from the persistent artifact`, result);
+    }
+  }
+  for(const [key, expected] of Object.entries(artifact.scoringRules || {})){
+    if((+result.scoreCases[key] || 0) !== (+expected || 0)){
+      fail(`Runtime scoring rule ${key} drifted from the persistent artifact`, result);
+    }
+  }
+  const expectations = artifact.runtimeExpectations || {};
+  const band = expectations.firstEnemyShotBandSeconds || [];
+  const firstShotT = +result.events.firstEnemyShot?.t;
+  if(!Number.isFinite(firstShotT) || firstShotT < band[0] || firstShotT > band[1]){
+    fail('First enemy-shot timing drifted outside the threat/scoring artifact band', result);
+  }
+  if(result.events.enemyShotCount < expectations.minimumEnemyShotsBySixSeconds){
+    fail('Runtime did not produce enough lower-field shot pressure by six seconds', result);
+  }
+  if(result.events.liveEnemyShotCount > expectations.maximumLiveEnemyShots){
+    fail('Runtime exceeded the enemy-shot live cap', result);
+  }
+  if(!result.events.audioCueIds.includes(expectations.requiredAudioCueId)){
+    fail('Runtime did not emit the owned Guardians enemy-shot cue id', result);
+  }
+  if(result.events.loss?.cause !== expectations.requiredPlayerLossCause){
+    fail('Enemy shot did not resolve to the expected player-loss cause', result);
+  }
+  if(!adapterSource.includes("event.type==='enemy_shot'") || !adapterSource.includes("return 'enemyShot'")){
+    fail('Guardians adapter does not map enemy_shot events to the owned enemyShot cue', result);
+  }
+  if((lossState.forbiddenAuroraCapabilities || {}).usesCaptureRescue !== 0 || Object.prototype.hasOwnProperty.call(lossState, 'captureRescue')){
+    fail('Enemy-shot player loss leaked Aurora capture/dual-fighter state into Guardians', result);
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    artifact: path.relative(ROOT, ARTIFACT),
+    firstEnemyShotT: firstShotT,
+    enemyShotEventsBySixSeconds: result.events.enemyShotCount,
+    liveEnemyShotCount: result.events.liveEnemyShotCount,
+    lossCause: result.events.loss.cause,
+    scoreCases: result.scoreCases
+  }, null, 2));
+}
+
+try {
+  main();
+} catch (err) {
+  fail(err && err.stack || String(err));
+}


### PR DESCRIPTION
## Summary
- add a persistent Galaxy Guardians threat/scoring artifact for the 0.1 preview track
- add enemy-shot timing, live-shot caps, collision loss, cue mapping, and visible shot rendering to the dev runtime
- verify Guardians-owned scoring values for formation, dive, and escorted flagship hits
- document the new artifact and harness in the Platinum application and architecture docs

## Verification
- npm run build
- npm run harness:check:galaxy-guardians-threat-scoring
- npm run harness:check:galaxy-guardians-movement-pacing
- npm run harness:check:galaxy-guardians-runtime-slice
- npm run harness:check:galaxy-guardians-identity-baseline
- npm run harness:check:galaxy-guardians-playable-preview
- npm run harness:check:platinum-renderer-boundaries
- npm run harness:check:compact-cabinet-rails
- git diff --check

## Release authority
No beta or production publish action was run from this MacBook.