### PR TITLE
Stabilize browser harness launches on macOS

### DIFF
--- a/DEVELOPER_MACHINE_BASELINE.md
+++ b/DEVELOPER_MACHINE_BASELINE.md
@@ -34,7 +34,8 @@ Verified on this machine on `2026-04-24`:
 - `npm`: `11.11.1`
 - `python3`: `3.12.1`
 - `gh`: `2.37.0`
-- `Google Chrome`: `147.0.7727.56`
+- `Google Chrome`: useful for manual local review
+- Playwright-managed Chromium: required for automated browser harnesses
 
 The exact versions do not need to match perfectly, but a new machine should
 record its actual versions in a setup note when first verified.
@@ -48,8 +49,15 @@ node -v
 npm -v
 python3 --version
 gh --version | head -n 1
-'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' --version
+npm run machine:ensure-browser
+npm run machine:doctor
 ```
+
+Browser-backed harnesses intentionally use Playwright-managed Chromium instead
+of the user's installed Google Chrome. In Codex Desktop on macOS, run those
+harness commands outside the filesystem sandbox / with escalated sandbox
+permissions; the launcher refuses sandboxed browser starts because macOS denies
+Chromium Mach-port registration there and can raise crash dialogs.
 
 ## Repo Setup
 
@@ -66,6 +74,7 @@ This command:
 - clones `sgwoods/Codex-Test1` into `./Codex-Test1` if needed
 - reuses the clone if it already exists
 - runs `npm run machine:bootstrap`
+- installs Playwright-managed Chromium for browser-backed harnesses
 - and, on fresh macOS machines, attempts to install missing Aurora
   prerequisites through Apple Command Line Tools plus Homebrew
 - those prerequisite installs may request administrator approval

--- a/MACBOOK_CODEX_PROMPT.md
+++ b/MACBOOK_CODEX_PROMPT.md
@@ -70,6 +70,14 @@ Key local services:
 - Game: http://127.0.0.1:8000/
 - Viewer: http://127.0.0.1:4311/
 
+Browser harness rule:
+- Run `npm run machine:ensure-browser` through bootstrap before browser checks.
+- Browser-backed harnesses use Playwright-managed Chromium, not the user's
+  installed Google Chrome.
+- In Codex Desktop on macOS, run browser-backed harness commands with escalated
+  sandbox permissions; sandboxed browser starts can trigger Chromium/Chrome
+  SIGABRT crash dialogs.
+
 Important docs to read first before major work:
 - NEXT_CODEX_ACCOUNT_HANDOFF.md
 - RESTART_FROM_HERE.md

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Current go-forward focus:
 
 ```bash
 cd <repo-root>
+npm run machine:ensure-browser
 npm run build
 ```
 
@@ -163,6 +164,11 @@ To stop the tracked local services cleanly:
 ```bash
 npm run local:stop
 ```
+
+Automated browser harnesses use Playwright-managed Chromium, not the user's
+installed Google Chrome. In Codex Desktop on macOS, run browser-backed harnesses
+with escalated sandbox permissions so Chromium can register its macOS Mach port
+without triggering crash dialogs.
 
 ## Release Ladder
 

--- a/TESTING_AND_RELEASE_GATES.md
+++ b/TESTING_AND_RELEASE_GATES.md
@@ -20,12 +20,19 @@ Aurora now assumes:
 The practical startup and readiness commands are now:
 
 - `npm run machine:bootstrap`
+- `npm run machine:ensure-browser`
 - `npm run machine:doctor`
 - `npm run machine:status`
 - `npm run release:show-authority`
 
 This means machine readiness and release authority are now part of release
 discipline, not just local convention.
+
+Browser-backed gates use Playwright-managed Chromium. They must not launch the
+user's installed Google Chrome by default. In Codex Desktop on macOS, run these
+browser-backed commands with escalated sandbox permissions; the harness launcher
+will refuse sandboxed browser starts to avoid macOS Chromium/Chrome SIGABRT
+crash dialogs.
 
 ## Bug-Fix Discipline
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "machine:bootstrap": "node tools/dev/machine-bootstrap.js",
     "machine:doctor": "node tools/dev/machine-doctor.js",
     "machine:status": "node tools/dev/machine-status.js",
+    "machine:ensure-browser": "node tools/dev/ensure-playwright-browser.js",
     "local:resume": "node tools/dev/local-resume.js",
     "local:stop": "node tools/dev/local-stop.js",
     "harness:analyze": "node tools/harness/analyze-run.js",

--- a/tools/dev/ensure-playwright-browser.js
+++ b/tools/dev/ensure-playwright-browser.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+const path = require('path');
+const { ROOT } = require('../build/paths');
+const { resolveHarnessBrowser } = require('../harness/browser-launch');
+
+function main(){
+  const before = resolveHarnessBrowser();
+  if(before.ok && before.kind !== 'system-google-chrome-explicit-fallback'){
+    console.log(JSON.stringify({
+      ok: true,
+      action: 'already-installed',
+      browser: before
+    }, null, 2));
+    return;
+  }
+
+  const cli = path.join(ROOT, 'node_modules', 'playwright-core', 'cli.js');
+  const result = spawnSync(process.execPath, [cli, 'install', 'chromium'], {
+    cwd: ROOT,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      AURORA_HARNESS_ALLOW_SYSTEM_CHROME: ''
+    }
+  });
+  if(result.status !== 0){
+    process.exit(result.status || 1);
+  }
+  const after = resolveHarnessBrowser();
+  if(!after.ok || after.kind === 'system-google-chrome-explicit-fallback'){
+    console.error(JSON.stringify({
+      ok: false,
+      action: 'install-failed',
+      browser: after
+    }, null, 2));
+    process.exit(1);
+  }
+  console.log(JSON.stringify({
+    ok: true,
+    action: 'installed',
+    browser: after
+  }, null, 2));
+}
+
+main();

--- a/tools/dev/machine-bootstrap.js
+++ b/tools/dev/machine-bootstrap.js
@@ -19,7 +19,6 @@ async function main(){
   const missing = [];
   if(!checks.npm.ok) missing.push('npm');
   if(!checks.python3.ok) missing.push('python3');
-  if(!checks.chrome.ok) missing.push('chrome');
   if(!checks.gh.ok) missing.push('gh');
 
   if(missing.length){
@@ -48,6 +47,8 @@ async function main(){
 
   runCommandOrThrow('npm', ['install'], 'npm install');
   actions.push('npm install');
+  runCommandOrThrow('npm', ['run', 'machine:ensure-browser'], 'npm run machine:ensure-browser');
+  actions.push('npm run machine:ensure-browser');
   runCommandOrThrow('npm', ['run', 'build'], 'npm run build');
   actions.push('npm run build');
   runCommandOrThrow('npm', ['run', 'local:resume'], 'npm run local:resume');

--- a/tools/dev/machine-common.js
+++ b/tools/dev/machine-common.js
@@ -135,12 +135,19 @@ function commandVersion(command, args = ['--version']){
 }
 
 function toolChecks(){
+  let harnessBrowser = { ok: false, kind: 'unknown', path: '', message: '' };
+  try{
+    harnessBrowser = require('../harness/browser-launch').resolveHarnessBrowser();
+  }catch(err){
+    harnessBrowser = { ok: false, kind: 'error', path: '', message: String(err && err.message || err) };
+  }
   const checks = {
     node: { ok: true, version: process.version },
     npm: { ok: false, version: null },
     python3: { ok: false, version: null },
     gh: { ok: false, version: null, authenticated: false },
-    chrome: { ok: false, version: null, path: CHROME_PATH }
+    chrome: { ok: false, version: null, path: CHROME_PATH },
+    harness_browser: harnessBrowser
   };
 
   checks.npm.version = commandVersion('npm', ['-v']);
@@ -175,7 +182,8 @@ function buildMachineProfile(identity, checks, lastSuccessfulBootstrapAt = null)
       npm: checks.npm.version,
       python3: checks.python3.version,
       gh: checks.gh.version,
-      chrome: checks.chrome.version
+      chrome: checks.chrome.version,
+      harness_browser: checks.harness_browser.kind
     },
     gh_auth: checks.gh.authenticated,
     last_successful_bootstrap_at: lastSuccessfulBootstrapAt

--- a/tools/dev/machine-report.js
+++ b/tools/dev/machine-report.js
@@ -36,7 +36,7 @@ async function gatherMachineSnapshot({ includePublic = false } = {}){
   const developmentBlocked = [];
   if(!tools.npm.ok) developmentBlocked.push('npm');
   if(!tools.python3.ok) developmentBlocked.push('python3');
-  if(!tools.chrome.ok) developmentBlocked.push('chrome');
+  if(!tools.harness_browser.ok) developmentBlocked.push('playwright-managed chromium');
   if(!remotes.ok) developmentBlocked.push('origin remote');
 
   const releaseBlocked = [];

--- a/tools/dev/setup-machine.sh
+++ b/tools/dev/setup-machine.sh
@@ -6,7 +6,6 @@ DEFAULT_TARGET="$PWD/Codex-Test1"
 TARGET_DIR="${1:-$DEFAULT_TARGET}"
 TARGET_DIR="${TARGET_DIR/#\~/$HOME}"
 
-CHROME_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 OS_NAME="$(uname -s)"
 BrewBinCandidates=(
   "/opt/homebrew/bin/brew"
@@ -187,7 +186,7 @@ ensure_mac_prerequisites() {
   local python_present="no"
   [[ "$OS_NAME" == "Darwin" ]] || return 0
 
-  if ! have_tool git || ! have_tool node || ! have_tool npm || ! have_tool python3 || ! have_tool gh || [[ ! -x "$CHROME_PATH" ]]; then
+  if ! have_tool git || ! have_tool node || ! have_tool npm || ! have_tool python3 || ! have_tool gh; then
     needs_brew="yes"
   fi
 
@@ -216,7 +215,6 @@ EOF
   fi
   brew_install_if_missing formula python "$python_present"
   brew_install_if_missing formula gh "$(have_tool gh && echo yes || echo no)"
-  brew_install_if_missing cask google-chrome "$([[ -x "$CHROME_PATH" ]] && echo yes || echo no)"
   hash -r
 }
 
@@ -227,12 +225,6 @@ require_tool node "Install Node.js, then rerun this setup script."
 require_tool npm "Install npm, then rerun this setup script."
 require_tool python3 "Install Python 3, then rerun this setup script."
 require_tool gh "Install GitHub CLI (gh), then rerun this setup script."
-
-if [[ ! -x "$CHROME_PATH" ]]; then
-  echo "Missing required browser: Google Chrome"
-  echo "Expected at: $CHROME_PATH"
-  exit 1
-fi
 
 if [[ "$TARGET_DIR" == "$HOME/Library/Mobile Documents/"* ]]; then
   echo "Using an iCloud-backed Aurora clone path:"
@@ -295,6 +287,7 @@ echo "  npm run machine:bootstrap"
 echo
 echo "Next useful commands:"
 echo "  cd \"$TARGET_DIR\""
+echo "  npm run machine:ensure-browser"
 echo "  npm run machine:status"
 echo "  npm run machine:doctor"
 echo "  npm run release:show-authority"

--- a/tools/harness/browser-check-util.js
+++ b/tools/harness/browser-check-util.js
@@ -1,12 +1,12 @@
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
-const { chromium } = require('playwright-core');
 const { DIST_DEV } = require('../build/paths');
+const { SYSTEM_CHROME, launchHarnessBrowser } = require('./browser-launch');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const APP_ROOT = DIST_DEV;
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const CHROME = SYSTEM_CHROME;
 
 function mime(file){
   if(file.endsWith('.html')) return 'text/html; charset=utf-8';
@@ -40,17 +40,12 @@ function sleep(ms){
 }
 
 async function withHarnessPage(cfg, fn){
-  if(!fs.existsSync(CHROME)) throw new Error(`Chrome not found at ${CHROME}`);
   const appRoot = cfg.root ? path.resolve(cfg.root) : APP_ROOT;
   if(!fs.existsSync(path.join(appRoot, 'index.html'))){
     throw new Error(`Built app not found at ${appRoot}. Run "npm run build" first.`);
   }
   const { server, port } = await serve(appRoot);
-  const browser = await chromium.launch({
-    executablePath: CHROME,
-    headless: cfg.headed ? false : true,
-    args: ['--autoplay-policy=no-user-gesture-required']
-  });
+  const browser = await launchHarnessBrowser(cfg);
   try{
     const context = await browser.newContext({
       acceptDownloads: true,

--- a/tools/harness/browser-launch.js
+++ b/tools/harness/browser-launch.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+const { ROOT } = require('../build/paths');
+
+const SYSTEM_CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const INSTALL_COMMAND = 'npm run machine:bootstrap';
+
+function loadChromium(){
+  return require('playwright-core').chromium;
+}
+
+function configuredBrowserPath(){
+  const explicit = process.env.AURORA_HARNESS_BROWSER_PATH || '';
+  return explicit && fs.existsSync(explicit) ? explicit : '';
+}
+
+function playwrightChromiumPath(){
+  try{
+    const candidate = loadChromium().executablePath();
+    return candidate && fs.existsSync(candidate) ? candidate : '';
+  }catch{
+    return '';
+  }
+}
+
+function systemChromePath(){
+  return fs.existsSync(SYSTEM_CHROME) ? SYSTEM_CHROME : '';
+}
+
+function resolveHarnessBrowser(){
+  const explicit = configuredBrowserPath();
+  if(explicit){
+    return { ok: true, kind: 'explicit', path: explicit };
+  }
+  const managed = playwrightChromiumPath();
+  if(managed){
+    return { ok: true, kind: 'playwright-managed-chromium', path: managed };
+  }
+  if(process.env.AURORA_HARNESS_ALLOW_SYSTEM_CHROME === '1'){
+    const system = systemChromePath();
+    if(system){
+      return { ok: true, kind: 'system-google-chrome-explicit-fallback', path: system };
+    }
+  }
+  return {
+    ok: false,
+    kind: 'missing-playwright-managed-chromium',
+    path: '',
+    message: `Playwright-managed Chromium is not installed. Run "${INSTALL_COMMAND}" before browser-backed harnesses.`
+  };
+}
+
+function browserLaunchArgs(extraArgs=[]){
+  return [
+    '--autoplay-policy=no-user-gesture-required',
+    '--disable-crash-reporter',
+    '--disable-breakpad',
+    ...extraArgs
+  ];
+}
+
+async function launchHarnessBrowser(cfg={}){
+  if(process.env.CODEX_SANDBOX && process.env.AURORA_ALLOW_CODEX_SANDBOX_BROWSER !== '1'){
+    throw new Error(
+      'Browser-backed Aurora harnesses must run outside the Codex filesystem sandbox on macOS. '
+      + 'The sandbox denies Chromium Mach-port registration and can produce Google Chrome/Chromium SIGABRT crash dialogs. '
+      + 'In Codex Desktop, rerun this npm harness command with escalated sandbox permissions; normal Terminal runs are unaffected.'
+    );
+  }
+  const browser = resolveHarnessBrowser();
+  if(!browser.ok){
+    throw new Error(browser.message);
+  }
+  return loadChromium().launch({
+    executablePath: browser.path,
+    headless: cfg.headed ? false : true,
+    args: browserLaunchArgs(cfg.args || [])
+  });
+}
+
+module.exports = {
+  ROOT,
+  SYSTEM_CHROME,
+  INSTALL_COMMAND,
+  resolveHarnessBrowser,
+  launchHarnessBrowser,
+  browserLaunchArgs
+};

--- a/tools/harness/check-feedback-submit-path.js
+++ b/tools/harness/check-feedback-submit-path.js
@@ -2,11 +2,10 @@
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
-const { chromium } = require('playwright-core');
+const { launchHarnessBrowser } = require('./browser-launch');
 const { DIST_DEV } = require('../build/paths');
 
 const APP_ROOT = DIST_DEV;
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 
 function fail(message, payload){
   console.error(message);
@@ -111,17 +110,12 @@ async function runFailureCase(page){
 }
 
 async function main(){
-  if(!fs.existsSync(CHROME)) throw new Error(`Chrome not found at ${CHROME}`);
   if(!fs.existsSync(path.join(APP_ROOT, 'index.html'))){
     throw new Error(`Built dev app not found at ${APP_ROOT}. Run "npm run build" first.`);
   }
 
   const { server, port } = await serve(APP_ROOT);
-  const browser = await chromium.launch({
-    executablePath: CHROME,
-    headless: true,
-    args: ['--autoplay-policy=no-user-gesture-required']
-  });
+  const browser = await launchHarnessBrowser();
 
   try{
     const context = await browser.newContext({ viewport: { width: 1440, height: 1600 } });

--- a/tools/harness/check-input-mapping.js
+++ b/tools/harness/check-input-mapping.js
@@ -2,11 +2,10 @@
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
-const { chromium } = require('playwright-core');
+const { launchHarnessBrowser } = require('./browser-launch');
 const { DIST_DEV } = require('../build/paths');
 
 const APP_ROOT = DIST_DEV;
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 
 function fail(message, payload){
   console.error(message);
@@ -77,17 +76,12 @@ async function moveWithKey(page, key){
 }
 
 async function main(){
-  if(!fs.existsSync(CHROME)) throw new Error(`Chrome not found at ${CHROME}`);
   if(!fs.existsSync(path.join(APP_ROOT, 'index.html'))){
     throw new Error(`Built dev app not found at ${APP_ROOT}. Run "npm run build" first.`);
   }
 
   const { server, port } = await serve(APP_ROOT);
-  const browser = await chromium.launch({
-    executablePath: CHROME,
-    headless: true,
-    args: ['--autoplay-policy=no-user-gesture-required']
-  });
+  const browser = await launchHarnessBrowser();
 
   try{
     const context = await browser.newContext({ viewport: { width: 1440, height: 1600 } });

--- a/tools/harness/check-live-lane-input.js
+++ b/tools/harness/check-live-lane-input.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 const fs = require('fs');
-const { chromium } = require('playwright-core');
+const { launchHarnessBrowser } = require('./browser-launch');
 
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 
 function parseArgs(argv){
   const args = {};
@@ -77,12 +76,7 @@ async function main(){
   const args = parseArgs(process.argv.slice(2));
   const lane = String(args.lane || 'production').toLowerCase();
   const url = laneUrl(lane);
-  if(!fs.existsSync(CHROME)) throw new Error(`Chrome not found at ${CHROME}`);
-  const browser = await chromium.launch({
-    executablePath: CHROME,
-    headless: true,
-    args: ['--autoplay-policy=no-user-gesture-required']
-  });
+  const browser = await launchHarnessBrowser();
   try{
     const context = await browser.newContext({ viewport: { width: 1600, height: 1700 } });
     const page = await context.newPage();

--- a/tools/harness/check-non-production-score-path.js
+++ b/tools/harness/check-non-production-score-path.js
@@ -2,11 +2,10 @@
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
-const { chromium } = require('playwright-core');
+const { launchHarnessBrowser } = require('./browser-launch');
 const { DIST_DEV } = require('../build/paths');
 
 const APP_ROOT = DIST_DEV;
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 
 function fail(message, payload){
   console.error(message);
@@ -42,17 +41,12 @@ function serve(root = APP_ROOT){
 }
 
 async function main(){
-  if(!fs.existsSync(CHROME)) throw new Error(`Chrome not found at ${CHROME}`);
   if(!fs.existsSync(path.join(APP_ROOT, 'index.html'))){
     throw new Error(`Built app not found at ${APP_ROOT}. Run "npm run build" first.`);
   }
 
   const { server, port } = await serve(APP_ROOT);
-  const browser = await chromium.launch({
-    executablePath: CHROME,
-    headless: true,
-    args: ['--autoplay-policy=no-user-gesture-required']
-  });
+  const browser = await launchHarnessBrowser();
 
   try{
     const context = await browser.newContext({ acceptDownloads: true, viewport: { width: 1440, height: 1800 } });

--- a/tools/harness/check-production-account-feedback.js
+++ b/tools/harness/check-production-account-feedback.js
@@ -2,11 +2,10 @@
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
-const { chromium } = require('playwright-core');
+const { launchHarnessBrowser } = require('./browser-launch');
 const { DIST_PRODUCTION } = require('../build/paths');
 
 const APP_ROOT = DIST_PRODUCTION;
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 
 function fail(message, payload){
   console.error(message);
@@ -42,17 +41,12 @@ function serve(root = APP_ROOT){
 }
 
 async function main(){
-  if(!fs.existsSync(CHROME)) throw new Error(`Chrome not found at ${CHROME}`);
   if(!fs.existsSync(path.join(APP_ROOT, 'index.html'))){
     throw new Error(`Built production app not found at ${APP_ROOT}. Run "npm run promote:production" first.`);
   }
 
   const { server, port } = await serve(APP_ROOT);
-  const browser = await chromium.launch({
-    executablePath: CHROME,
-    headless: true,
-    args: ['--autoplay-policy=no-user-gesture-required']
-  });
+  const browser = await launchHarnessBrowser();
 
   try{
     const context = await browser.newContext({ viewport: { width: 1440, height: 1800 } });

--- a/tools/harness/check-remote-score-submit.js
+++ b/tools/harness/check-remote-score-submit.js
@@ -2,11 +2,10 @@
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
-const { chromium } = require('playwright-core');
+const { launchHarnessBrowser } = require('./browser-launch');
 const { DIST_DEV } = require('../build/paths');
 
 const APP_ROOT = DIST_DEV;
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 
 function fail(message, payload){
   console.error(message);
@@ -100,17 +99,12 @@ async function runFailureCase(page){
 }
 
 async function main(){
-  if(!fs.existsSync(CHROME)) throw new Error(`Chrome not found at ${CHROME}`);
   if(!fs.existsSync(path.join(APP_ROOT, 'index.html'))){
     throw new Error(`Built dev app not found at ${APP_ROOT}. Run "npm run build" first.`);
   }
 
   const { server, port } = await serve(APP_ROOT);
-  const browser = await chromium.launch({
-    executablePath: CHROME,
-    headless: true,
-    args: ['--autoplay-policy=no-user-gesture-required']
-  });
+  const browser = await launchHarnessBrowser();
 
   try{
     const context = await browser.newContext({ viewport: { width: 1440, height: 1600 } });

--- a/tools/harness/run-aurora-evidence-window-cycle.js
+++ b/tools/harness/run-aurora-evidence-window-cycle.js
@@ -3,12 +3,11 @@ const fs = require('fs');
 const http = require('http');
 const path = require('path');
 const { spawnSync } = require('child_process');
-const { chromium } = require('playwright-core');
+const { launchHarnessBrowser } = require('./browser-launch');
 const { DIST_DEV } = require('../build/paths');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const APP_ROOT = DIST_DEV;
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 const PLAN_PATH = path.join(ROOT, 'reference-artifacts', 'analyses', 'aurora-level-expansion-cycle', 'aurora-four-window-cycle.plan.json');
 const SCENARIO_ROOT = path.join(ROOT, 'tools', 'harness', 'scenarios');
 
@@ -476,15 +475,10 @@ function harnessTargets(win, eventLog){
 }
 
 async function main(){
-  if(!fs.existsSync(CHROME)) throw new Error(`Chrome not found at ${CHROME}`);
   if(!fs.existsSync(path.join(APP_ROOT, 'index.html'))) throw new Error('Built app missing. Run npm run build first.');
   const plan = readJson(PLAN_PATH);
   const { server, port } = await serve(APP_ROOT);
-  const browser = await chromium.launch({
-    executablePath: CHROME,
-    headless: true,
-    args: ['--autoplay-policy=no-user-gesture-required']
-  });
+  const browser = await launchHarnessBrowser();
   try{
     const results = [];
     for(const win of plan.windows || []){

--- a/tools/harness/run-gameplay.js
+++ b/tools/harness/run-gameplay.js
@@ -5,12 +5,11 @@ const path = require('path');
 const { analyze } = require('./analyze-run');
 const { writePortableSummary } = require('./summary-path-util');
 const { ensureUsableVideoArtifact } = require('./video-artifact-util');
-const { chromium } = require('playwright-core');
+const { launchHarnessBrowser } = require('./browser-launch');
 const { DIST_DEV } = require('../build/paths');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const APP_ROOT = DIST_DEV;
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 const DEFAULT_OUT = path.join(ROOT, 'harness-artifacts');
 const SCENARIOS = path.join(__dirname, 'scenarios');
 
@@ -279,7 +278,6 @@ async function main(){
     console.log('Optional: --auto-video 0|1');
     process.exit(args.help ? 0 : 1);
   }
-  if(!fs.existsSync(CHROME)) throw new Error(`Chrome not found at ${CHROME}`);
   const appRoot = args.root ? path.resolve(String(args.root)) : APP_ROOT;
   if(!fs.existsSync(path.join(appRoot, 'index.html'))){
     throw new Error(`Built app not found at ${appRoot}. Run "npm run build" first.`);
@@ -301,11 +299,7 @@ async function main(){
   const initAutoVideo = spec.autoVideo === false ? '0' : '1';
 
   const { server, port } = await serve(appRoot);
-  const browser = await chromium.launch({
-    executablePath: CHROME,
-    headless: args.headed ? false : true,
-    args: ['--autoplay-policy=no-user-gesture-required']
-  });
+  const browser = await launchHarnessBrowser({ headed: !!args.headed });
 
   try{
     const context = await browser.newContext({


### PR DESCRIPTION
## Summary
- add a shared browser launcher that defaults browser-backed harnesses to Playwright-managed Chromium instead of installed Google Chrome
- refuse sandboxed Codex Desktop browser launches before Chromium starts, avoiding macOS Mach-port SIGABRT crash dialogs
- add npm run machine:ensure-browser and wire it into bootstrap/doctor readiness
- move standalone browser harnesses onto the shared launcher
- document the new browser-harness rule in setup and testing docs

## Verification
- npm run machine:ensure-browser
- npm run machine:doctor
- npm run build
- npm run harness:check:compact-cabinet-rails outside Codex sandbox
- npm run harness:check:galaxy-guardians-runtime-slice outside Codex sandbox
- sandbox refusal smoke for launchHarnessBrowser
- node --check browser/dev harness files
- bash -n tools/dev/setup-machine.sh
- git diff --check

## Notes
- input-mapping and remote-score-submit now launch through the shared browser path, but both currently reach existing product/assertion failures unrelated to browser startup.
- No beta or production publish action was run from this MacBook.